### PR TITLE
fix: misc bug fixes batch (ESM, hibernate, context menu, file format)

### DIFF
--- a/features/subWiki.feature
+++ b/features/subWiki.feature
@@ -184,7 +184,7 @@ Feature: Sub-Wiki Functionality
     # Verify the setting was saved to settings.json
     Then settings.json should have workspace "SubWikiSettings" with "includeTagTree" set to "true"
 
-  @subwiki @subwiki-create-ui
+  @subwiki @subwiki-create-ui @calibrate
   Scenario: Create sub-wiki workspace via UI
     # This tests creating a sub-wiki through the Add Workspace UI
     Given I cleanup test wiki so it could create a new one on start

--- a/localization/locales/en/translation.json
+++ b/localization/locales/en/translation.json
@@ -351,6 +351,8 @@
     "UndoCommit": "Undo this commit",
     "Undoing": "Undoing...",
     "Syncing": "Synchronizing...",
+    "SyncSettings": "Sync Settings",
+    "SyncSettingsDescription": "After changing sync settings here, unpushed commits can be pushed to remote.",
     "SearchCommits": "Search commits...",
     "SearchMode": "Search Mode",
     "SelectCommit": "Select a submission to view details",

--- a/localization/locales/zh-Hans/translation.json
+++ b/localization/locales/zh-Hans/translation.json
@@ -348,6 +348,8 @@
     "UndoCommit": "撤回此提交",
     "Undoing": "撤回中...",
     "Syncing": "同步中...",
+    "SyncSettings": "同步设置",
+    "SyncSettingsDescription": "在此修改仓库同步设置后，未推送的提交将可以推送到远程。",
     "SearchCommits": "搜索提交记录...",
     "SearchMode": "搜索模式",
     "SelectCommit": "选择一个提交来查看详情",

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { TIDGI_PROTOCOL_SCHEME } from '@/constants/protocol';
 import { container } from '@services/container';
 import { initRendererI18NHandler } from '@services/libs/i18n';
 import { destroyLogger, logger } from '@services/libs/log';
-import { initializeMcpServer } from '@services/mcpServer';
+import { initializeMcpServer, stopMcpServer } from '@services/mcpServer';
 import { buildLanguageMenu } from '@services/menu/buildLanguageMenu';
 
 // Initialize loggers for modules that can't directly import logger (to avoid electron in worker bundles)
@@ -102,9 +102,8 @@ const runBeforeQuitCleanup = async (): Promise<void> => {
   logger.info('App before-quit - starting cleanup');
   try {
     logger.info('App before-quit - tidgi mini window closed');
-    // Dynamic import to avoid loading MCP SDK at startup
+    // MCP server may not be loaded if MCP is not configured
     try {
-      const { stopMcpServer } = await import('@services/mcpServer');
       void stopMcpServer();
     } catch { /* not loaded */ }
     // Stop all wiki workers FIRST - must be sequential

--- a/src/services/agentInstance/__tests__/index.failure.test.ts
+++ b/src/services/agentInstance/__tests__/index.failure.test.ts
@@ -3,6 +3,7 @@ import type { IDatabaseService } from '@services/database/interface';
 import { AgentDefinitionEntity, AgentInstanceEntity, AgentInstanceMessageEntity } from '@services/database/schema/agent';
 import * as callProvider from '@services/externalAPI/callProviderAPI';
 import type { IExternalAPIService } from '@services/externalAPI/interface';
+import type { IPreferenceService } from '@services/preferences/interface';
 import serviceIdentifier from '@services/serviceIdentifier';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentInstanceService } from '..';
@@ -39,7 +40,7 @@ describe('AgentInstance failure path - external API logs on error', () => {
     });
 
     // Enable debug logs
-    const pref = container.get<import('@services/preferences/interface').IPreferenceService>(serviceIdentifier.Preference);
+    const pref = container.get<IPreferenceService>(serviceIdentifier.Preference);
     await pref.set('externalAPIDebug', true);
 
     // Configure AI settings provider/model

--- a/src/services/agentInstance/__tests__/index.streaming.test.ts
+++ b/src/services/agentInstance/__tests__/index.streaming.test.ts
@@ -6,8 +6,7 @@ import { nanoid } from 'nanoid';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Use shared mocks via test container (setup-vitest binds serviceInstances into the container)
 import type { IAgentDefinitionService } from '@services/agentDefinition/interface';
-import type { AgentInstance } from '@services/agentInstance/interface';
-import type { IAgentInstanceService } from '@services/agentInstance/interface';
+import type { AgentInstance, AgentInstanceLatestStatus, IAgentInstanceService } from '@services/agentInstance/interface';
 import { container } from '@services/container';
 import type { IDatabaseService } from '@services/database/interface';
 import type { IExternalAPIService } from '@services/externalAPI/interface';
@@ -182,7 +181,7 @@ describe('AgentInstanceService Streaming Behavior', () => {
 
     // Track agent updates to capture the AI message ID
     let aiMessageId: string | undefined;
-    const messageUpdates: (import('@services/agentInstance/interface').AgentInstanceLatestStatus | undefined)[] = [];
+    const messageUpdates: (AgentInstanceLatestStatus | undefined)[] = [];
     let messageSubscription: import('rxjs').Subscription | undefined;
 
     const agentSubscription = agentInstanceService.subscribeToAgentUpdates(testAgentInstance.id).subscribe(update => {

--- a/src/services/agentInstance/agentFrameworks/__tests__/taskAgent.failure.test.ts
+++ b/src/services/agentInstance/agentFrameworks/__tests__/taskAgent.failure.test.ts
@@ -4,6 +4,7 @@ import type { IDatabaseService } from '@services/database/interface';
 import { AgentDefinitionEntity, AgentInstanceEntity, AgentInstanceMessageEntity } from '@services/database/schema/agent';
 import * as callProvider from '@services/externalAPI/callProviderAPI';
 import type { IExternalAPIService } from '@services/externalAPI/interface';
+import type { IPreferenceService } from '@services/preferences/interface';
 import serviceIdentifier from '@services/serviceIdentifier';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentInstanceMessage, IAgentInstanceService } from '../../interface';
@@ -68,7 +69,7 @@ describe('basicPromptConcatHandler - failure path persists error message and log
     });
 
     // Ensure external API debug is on so logs are attempted
-    const pref = container.get<import('@services/preferences/interface').IPreferenceService>(serviceIdentifier.Preference);
+    const pref = container.get<IPreferenceService>(serviceIdentifier.Preference);
     await pref.set('externalAPIDebug', true);
 
     // Ensure AI provider settings present so ExternalAPI can resolve providerConfig

--- a/src/services/agentInstance/index.ts
+++ b/src/services/agentInstance/index.ts
@@ -14,7 +14,7 @@ import type { PromptConcatStreamState } from '@services/agentInstance/promptConc
 import { createHooksWithPlugins, initializePluginSystem } from '@services/agentInstance/tools';
 import { container } from '@services/container';
 import type { IDatabaseService } from '@services/database/interface';
-import { AgentInstanceEntity, AgentInstanceMessageEntity } from '@services/database/schema/agent';
+import { AgentInstanceEntity, AgentInstanceMessageEntity, ScheduledTaskEntity } from '@services/database/schema/agent';
 import type { IGitService } from '@services/git/interface';
 import { logger } from '@services/libs/log';
 import serviceIdentifier from '@services/serviceIdentifier';
@@ -91,7 +91,6 @@ export class AgentInstanceService implements IAgentInstanceService {
       this.agentMessageRepository = this.dataSource.getRepository(AgentInstanceMessageEntity);
 
       // Initialize the unified ScheduledTaskManager
-      const { ScheduledTaskEntity } = await import('@services/database/schema/agent');
       const stmRepo = this.dataSource.getRepository(ScheduledTaskEntity);
       initScheduledTaskManager(stmRepo, this);
       this.scheduledTaskRepositoryReady = true;
@@ -189,7 +188,6 @@ export class AgentInstanceService implements IAgentInstanceService {
   private async restoreScheduledTaskManagerTasks(): Promise<void> {
     if (!this.scheduledTaskRepositoryReady || !this.agentInstanceRepository) return;
     try {
-      const { ScheduledTaskEntity } = await import('@services/database/schema/agent');
       const stmRepo = this.dataSource!.getRepository(ScheduledTaskEntity);
 
       const isVolatile = async (agentInstanceId: string): Promise<boolean> => {

--- a/src/services/agentInstance/tools/alarmClock.ts
+++ b/src/services/agentInstance/tools/alarmClock.ts
@@ -5,7 +5,7 @@
  */
 import { container } from '@services/container';
 import type { IDatabaseService } from '@services/database/interface';
-import { AgentInstanceEntity } from '@services/database/schema/agent';
+import { AgentInstanceEntity, type ScheduleConfig } from '@services/database/schema/agent';
 import { t } from '@services/libs/i18n/placeholder';
 import { logger } from '@services/libs/log';
 import serviceIdentifier from '@services/serviceIdentifier';
@@ -327,7 +327,7 @@ const alarmClockDefinition = registerToolDefinition({
     if (toolCall.toolId === 'schedule-task') {
       await executeToolCall('schedule-task', async (parameters) => {
         const { addTask } = await import('../scheduledTaskManager');
-        let schedule: import('@services/database/schema/agent').ScheduleConfig;
+        let schedule: ScheduleConfig;
 
         if (parameters.kind === 'interval') {
           const intervalSeconds = Math.max(60, parameters.intervalSeconds ?? 300);

--- a/src/services/agentInstance/tools/editAgentDefinition.ts
+++ b/src/services/agentInstance/tools/editAgentDefinition.ts
@@ -3,7 +3,10 @@
  * Supports updating the heartbeat schedule, tool approvals, and system prompt config.
  * Operates with approval mode "confirm" by default (user must approve each change).
  */
+import { container } from '@services/container';
+import type { IAgentDefinitionService } from '@services/agentDefinition/interface';
 import { t } from '@services/libs/i18n/placeholder';
+import serviceIdentifier from '@services/serviceIdentifier';
 import { z } from 'zod/v4';
 import { registerToolDefinition } from './defineTool';
 
@@ -82,8 +85,6 @@ const editAgentDefinitionDefinition = registerToolDefinition({
 
     if (toolCall.toolId === 'edit-heartbeat') {
       await executeToolCall('edit-heartbeat', async (parameters) => {
-        const { container } = await import('@services/container');
-        const serviceIdentifier = (await import('@services/serviceIdentifier')).default;
         const agentInstanceService = container.get<import('../interface').IAgentInstanceService>(serviceIdentifier.AgentInstance);
 
         await agentInstanceService.setBackgroundHeartbeat(agentId, {
@@ -106,15 +107,12 @@ const editAgentDefinitionDefinition = registerToolDefinition({
 
     if (toolCall.toolId === 'edit-agent-prompt-config') {
       await executeToolCall('edit-agent-prompt-config', async (parameters) => {
-        const { container } = await import('@services/container');
-        const serviceIdentifier = (await import('@services/serviceIdentifier')).default;
         const agentInstanceService = container.get<import('../interface').IAgentInstanceService>(serviceIdentifier.AgentInstance);
 
         const agent = await agentInstanceService.getAgent(agentId);
         if (!agent) throw new Error(`Agent not found: ${agentId}`);
 
-        const { container: iocContainer } = await import('@services/container');
-        const agentDefinitionService = iocContainer.get<import('@services/agentDefinition/interface').IAgentDefinitionService>(serviceIdentifier.AgentDefinition);
+        const agentDefinitionService = container.get<IAgentDefinitionService>(serviceIdentifier.AgentDefinition);
 
         const agentDefinition = await agentDefinitionService.getAgentDef(agent.agentDefId);
         if (!agentDefinition) throw new Error(`Agent definition not found: ${agent.agentDefId}`);

--- a/src/services/agentInstance/tools/editAgentDefinition.ts
+++ b/src/services/agentInstance/tools/editAgentDefinition.ts
@@ -3,8 +3,8 @@
  * Supports updating the heartbeat schedule, tool approvals, and system prompt config.
  * Operates with approval mode "confirm" by default (user must approve each change).
  */
-import { container } from '@services/container';
 import type { IAgentDefinitionService } from '@services/agentDefinition/interface';
+import { container } from '@services/container';
 import { t } from '@services/libs/i18n/placeholder';
 import serviceIdentifier from '@services/serviceIdentifier';
 import { z } from 'zod/v4';

--- a/src/services/analytics/index.ts
+++ b/src/services/analytics/index.ts
@@ -1,9 +1,11 @@
-import { app, net } from 'electron';
+import { app, dialog, net } from 'electron';
 import { inject, injectable } from 'inversify';
 import { randomUUID } from 'node:crypto';
 
+import { isTest } from '@/constants/environment';
 import { container } from '@services/container';
 import type { IAnalyticsSecretSettings, IDatabaseService } from '@services/database/interface';
+import { i18n } from '@services/libs/i18n';
 import { logger } from '@services/libs/log';
 import type { IPreferenceService } from '@services/preferences/interface';
 import serviceIdentifier from '@services/serviceIdentifier';
@@ -94,10 +96,7 @@ export class AnalyticsService implements IAnalyticsService {
   }
 
   public async showDisclosureIfNeeded(): Promise<void> {
-    const { isTest } = await import('@/constants/environment');
     if (isTest || !(await this.shouldShowDisclosure())) return;
-    const { dialog } = await import('electron');
-    const { i18n } = await import('@services/libs/i18n');
     const result = await dialog.showMessageBox({
       type: 'question',
       title: i18n.t('AnalyticsDisclosure.Title'),

--- a/src/services/git/index.ts
+++ b/src/services/git/index.ts
@@ -45,6 +45,8 @@ export class Git implements IGitService {
   /**
    * Acquire a per-workspace lock to serialize git operations.
    * Returns a release function that must be called in a finally block.
+   * Includes a timeout so that if a previous operation is stuck (e.g. due to a hibernated workspace or a hung git process),
+   * the current operation fails fast instead of blocking indefinitely.
    */
   private async acquireOperationLock(workspaceID: string): Promise<() => void> {
     let release: () => void;
@@ -56,7 +58,13 @@ export class Git implements IGitService {
     this.operationLocks.set(workspaceID, promise);
 
     if (previousLock !== undefined) {
-      await previousLock;
+      const LOCK_TIMEOUT_MS = 30_000;
+      const timeoutPromise = new Promise<void>((_, reject) => {
+        setTimeout(() => {
+          reject(new Error(`Previous git operation is still running for workspace ${workspaceID} after ${LOCK_TIMEOUT_MS}ms`));
+        }, LOCK_TIMEOUT_MS);
+      });
+      await Promise.race([previousLock, timeoutPromise]);
     }
 
     return () => {
@@ -285,6 +293,10 @@ export class Git implements IGitService {
     }
     const workspaceIDToShowNotification = workspace.isSubWiki ? workspace.mainWikiID! : workspace.id;
     const workspaceID = workspace.id;
+    if (workspace.hibernated) {
+      logger.warn('commitAndSync skipped because workspace is hibernated', { workspaceID });
+      return false;
+    }
     const releaseLock = await this.acquireOperationLock(workspaceID);
     try {
       // Sub-wikis don't have their own wiki worker, so wikiOperationInServer would hang forever
@@ -343,6 +355,10 @@ export class Git implements IGitService {
     }
     const workspaceIDToShowNotification = workspace.isSubWiki ? workspace.mainWikiID! : workspace.id;
     const workspaceID = workspace.id;
+    if (workspace.hibernated) {
+      logger.warn('forcePull skipped because workspace is hibernated', { workspaceID });
+      return false;
+    }
     const releaseLock = await this.acquireOperationLock(workspaceID);
     try {
       const observable = this.gitWorker?.forcePullWiki(workspace, configs, getErrorMessageI18NDict());

--- a/src/services/menu/contextMenu/contextMenuBuilder.ts
+++ b/src/services/menu/contextMenu/contextMenuBuilder.ts
@@ -4,7 +4,7 @@
  */
 
 import { isMac } from '@/helpers/system';
-import { clipboard, Menu, MenuItem, shell, WebContents } from 'electron';
+import { clipboard, Menu, MenuItem, nativeImage, net, shell, WebContents } from 'electron';
 import i18next from 'i18next';
 import type { IOnContextMenuInfo } from '../interface';
 
@@ -274,6 +274,20 @@ export default class ContextMenuBuilder {
         clipboard.writeText(menuInfo.srcURL!);
       },
     });
+    const copyImage = new MenuItem({
+      label: this.stringTable.copy(),
+      click: () => {
+        net.fetch(menuInfo.srcURL!).then(async (response) => {
+          const arrayBuffer = await response.arrayBuffer();
+          const buffer = Buffer.from(arrayBuffer);
+          const image = nativeImage.createFromBuffer(buffer);
+          clipboard.writeImage(image);
+        }).catch((error: unknown) => {
+          console.error('Failed to copy image to clipboard', error);
+        });
+      },
+    });
+    menu.append(copyImage);
     menu.append(copyImageUrl);
     return menu;
   }

--- a/src/services/menu/contextMenu/contextMenuBuilder.ts
+++ b/src/services/menu/contextMenu/contextMenuBuilder.ts
@@ -275,12 +275,14 @@ export default class ContextMenuBuilder {
       },
     });
     const copyImage = new MenuItem({
-      label: this.stringTable.copy(),
+      label: this.stringTable.copyImage(),
       click: () => {
         net.fetch(menuInfo.srcURL!).then(async (response) => {
+          if (!response.ok) throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`);
           const arrayBuffer = await response.arrayBuffer();
           const buffer = Buffer.from(arrayBuffer);
           const image = nativeImage.createFromBuffer(buffer);
+          if (image.isEmpty()) throw new Error('Failed to decode image from fetched bytes');
           clipboard.writeImage(image);
         }).catch((error: unknown) => {
           console.error('Failed to copy image to clipboard', error);

--- a/src/services/native/reportError.ts
+++ b/src/services/native/reportError.ts
@@ -2,6 +2,7 @@ import { LOG_FOLDER } from '@/constants/appPaths';
 import { sanitizeErrorMessage } from '@services/analytics';
 import type { IAnalyticsService } from '@services/analytics/interface';
 import { container } from '@services/container';
+import { logger } from '@services/libs/log';
 import serviceIdentifier from '@services/serviceIdentifier';
 import { app, shell } from 'electron';
 import newGithubIssueUrl, { type Options as OpenNewGitHubIssueOptions } from 'new-github-issue-url';
@@ -76,17 +77,11 @@ export function reportErrorToGithubWithTemplates(error: Error): void {
     errorName: error.name || 'Error',
     errorMessage: sanitizeErrorMessage(error),
   });
-  void import('@services/container')
-    .then(({ container }) => {
-      const nativeService = container.get<INativeService>(serviceIdentifier.NativeService);
-      return nativeService.openPath(LOG_FOLDER, true);
-    })
-    .catch(async (error_: unknown) => {
-      const error = error_ as Error;
-      await import('@services/libs/log').then(({ logger }) => {
-        logger.error(`Failed to open LOG_FOLDER in reportErrorToGithubWithTemplates`, { error });
-      });
-    });
+  const nativeService = container.get<INativeService>(serviceIdentifier.NativeService);
+  void nativeService.openPath(LOG_FOLDER, true).catch((error_: unknown) => {
+    const error = error_ as Error;
+    logger.error(`Failed to open LOG_FOLDER in reportErrorToGithubWithTemplates`, { error });
+  });
 
   const sanitizedMessage = sanitizePaths(error.message ?? '');
   const sanitizedStack = sanitizePaths(error.stack ?? '');

--- a/src/services/sync/index.ts
+++ b/src/services/sync/index.ts
@@ -48,10 +48,9 @@ export class Sync implements ISyncService {
     const { force = false } = options ?? {};
     const syncOnlyWhenNoDraft = await this.preferenceService.get('syncOnlyWhenNoDraft');
     const mainWorkspace = isSubWiki ? workspaceService.getMainWorkspace(workspace) : undefined;
-    const hasRemoteAndAuth = typeof gitUrl === 'string' && userInfo !== undefined;
     const analyticsBaseProperties = {
       storage: storageService,
-      commitOnly: storageService === SupportedStorageServices.local && !hasRemoteAndAuth,
+      commitOnly: storageService === SupportedStorageServices.local,
       force,
     };
     if (isSubWiki && mainWorkspace === undefined) {
@@ -70,8 +69,8 @@ export class Sync implements ISyncService {
       return;
     }
     void analyticsService.track('sync.triggered', analyticsBaseProperties);
-    if (storageService === SupportedStorageServices.local && !hasRemoteAndAuth) {
-      // for local workspace without remote or without auth, commitOnly, no sync and no force pull.
+    if (storageService === SupportedStorageServices.local) {
+      // for local workspace, commitOnly, no sync and no force pull.
       const hasChanges = await gitService.commitAndSync(workspace, { dir: wikiFolderLocation, commitOnly: true, commitMessage: localCommitMessage });
       void analyticsService.track('sync.completed', {
         ...analyticsBaseProperties,

--- a/src/services/sync/index.ts
+++ b/src/services/sync/index.ts
@@ -48,9 +48,10 @@ export class Sync implements ISyncService {
     const { force = false } = options ?? {};
     const syncOnlyWhenNoDraft = await this.preferenceService.get('syncOnlyWhenNoDraft');
     const mainWorkspace = isSubWiki ? workspaceService.getMainWorkspace(workspace) : undefined;
+    const hasRemoteAndAuth = typeof gitUrl === 'string' && userInfo !== undefined;
     const analyticsBaseProperties = {
       storage: storageService,
-      commitOnly: storageService === SupportedStorageServices.local,
+      commitOnly: storageService === SupportedStorageServices.local && !hasRemoteAndAuth,
       force,
     };
     if (isSubWiki && mainWorkspace === undefined) {
@@ -69,8 +70,8 @@ export class Sync implements ISyncService {
       return;
     }
     void analyticsService.track('sync.triggered', analyticsBaseProperties);
-    if (storageService === SupportedStorageServices.local) {
-      // for local workspace, commitOnly, no sync and no force pull.
+    if (storageService === SupportedStorageServices.local && !hasRemoteAndAuth) {
+      // for local workspace without remote or without auth, commitOnly, no sync and no force pull.
       const hasChanges = await gitService.commitAndSync(workspace, { dir: wikiFolderLocation, commitOnly: true, commitMessage: localCommitMessage });
       void analyticsService.track('sync.completed', {
         ...analyticsBaseProperties,

--- a/src/services/sync/index.ts
+++ b/src/services/sync/index.ts
@@ -29,6 +29,10 @@ export class Sync implements ISyncService {
       logger.warn('syncWikiIfNeeded called on non-wiki workspace', { workspaceId: workspace.id });
       return;
     }
+    if (workspace.hibernated) {
+      logger.warn('syncWikiIfNeeded skipped because workspace is hibernated', { workspaceId: workspace.id });
+      return;
+    }
     logger.info('syncWikiIfNeeded started', { workspaceId: workspace.id, storageService: workspace.storageService, force: options?.force });
 
     // Get Layer 3 services

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
@@ -661,8 +661,8 @@ export class FileSystemWatcher {
         const newExtension = path.extname(actualFileAbsPath).toLowerCase();
         if (existingExtension === '.tid' && newExtension === '.json') {
           this.logger.alert(
-            `FileSystemWatcher WARNING: Tiddler "${tiddlerTitle}" format changed from .tid to .json! `
-            + `This may indicate a file format bug. Old: ${existingBootFile.filepath}, New: ${actualFileAbsPath}`,
+            `FileSystemWatcher WARNING: Tiddler "${tiddlerTitle}" format changed from .tid to .json! ` +
+              `This may indicate a file format bug. Old: ${existingBootFile.filepath}, New: ${actualFileAbsPath}`,
           );
         } else if (existingExtension === '.json' && newExtension === '.tid') {
           this.logger.log(

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
@@ -54,6 +54,17 @@ export interface IFileChange {
   type: 'add' | 'change' | 'delete';
   /** Cached tiddler fields loaded during detection, avoids re-reading file */
   cachedTiddlerFields?: Record<string, unknown>;
+  /**
+   * File-level descriptor from $tw.loadTiddlersFromFile().
+   * Contains file format type (e.g. 'application/x-tiddler' for .tid, 'application/json' for .json),
+   * which is DIFFERENT from the tiddler's content type (e.g. 'text/markdown').
+   * This is critical for preserving the correct file format on subsequent saves.
+   */
+  cachedFileDescriptor?: {
+    type: string | undefined;
+    hasMetaFile: boolean | undefined;
+    isEditableFile: boolean | undefined;
+  };
 }
 
 /**
@@ -229,11 +240,19 @@ export class FileSystemWatcher {
         // Normalize to forward slashes for consistency with the inverse index and TiddlyWiki's path convention.
         // On Windows, this prevents mismatch between native backslashes and TiddlyWiki's forward-slash paths.
         const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
+
+        // CRITICAL: Use the file descriptor's type (file format type), NOT the tiddler's content type.
+        // fileDescriptor.type = 'application/x-tiddler' for .tid files, 'application/json' for .json files
+        // tiddler.type = 'text/markdown', 'text/vnd.tiddlywiki', etc. (content type)
+        // If we use the tiddler's content type here, saveTiddlerToFile() will save as JSON
+        // because it only checks for 'application/x-tiddler' to use .tid format.
+        const fileType = fileChange.cachedFileDescriptor?.type ?? this.inferFileTypeFromExtension(fileChange.absolutePath);
+
         this.boot.files[title] = {
           filepath: normalizedPath,
-          type: (fileChange.cachedTiddlerFields.type as string) ?? 'application/x-tiddler',
-          hasMetaFile,
-          isEditableFile: true,
+          type: fileType,
+          hasMetaFile: fileChange.cachedFileDescriptor?.hasMetaFile ?? hasMetaFile,
+          isEditableFile: fileChange.cachedFileDescriptor?.isEditableFile ?? true,
         };
         callback(null, fileChange.cachedTiddlerFields);
         this.pendingFileLoads.delete(title);
@@ -265,9 +284,11 @@ export class FileSystemWatcher {
       const { tiddlers: _, ...fileDescriptor } = tiddlersDescriptor;
       // Normalize to forward slashes for consistency with the inverse index and TiddlyWiki's path convention.
       const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
+      // Validate file type: ensure it's a recognized file format type, not a content type
+      const fileType = (fileDescriptor.type as string) ?? this.inferFileTypeFromExtension(fileChange.absolutePath);
       this.boot.files[title] = {
         filepath: normalizedPath,
-        type: fileDescriptor.type ?? 'application/x-tiddler',
+        type: fileType,
         hasMetaFile: fileDescriptor.hasMetaFile ?? false,
         isEditableFile: fileDescriptor.isEditableFile ?? true,
       };
@@ -623,19 +644,49 @@ export class FileSystemWatcher {
         const wikiModified = (existingTiddler.fields.modified as string | undefined) ?? '';
         const fileText = (tiddler as { text?: string }).text ?? '';
         const wikiText = (existingTiddler.fields.text as string | undefined) ?? '';
-        if (fileModified !== '' && fileModified === wikiModified && fileText === wikiText) {
+        // Normalize line endings and trim for robust comparison
+        const normalizeForCompare = (s: string) => s.replace(/\r\n/g, '\n').trim();
+        if (fileModified !== '' && fileModified === wikiModified && normalizeForCompare(fileText) === normalizeForCompare(wikiText)) {
           this.logger.log(`FileSystemWatcher Skipping self-echo for ${tiddlerTitle} (content identical)`);
           continue;
         }
       }
 
+      // Detect unexpected file format changes (e.g., .tid → .json).
+      // This catches the bug where incorrect boot.files[title].type causes
+      // saveTiddlerToFile() to save in the wrong format.
+      const existingBootFile = this.boot.files[tiddlerTitle];
+      if (existingBootFile?.filepath) {
+        const existingExt = path.extname(existingBootFile.filepath).toLowerCase();
+        const newExt = path.extname(actualFileAbsPath).toLowerCase();
+        if (existingExt === '.tid' && newExt === '.json') {
+          this.logger.alert(
+            `FileSystemWatcher WARNING: Tiddler "${tiddlerTitle}" format changed from .tid to .json! `
+            + `This may indicate a file format bug. Old: ${existingBootFile.filepath}, New: ${actualFileAbsPath}`,
+          );
+        } else if (existingExt === '.json' && newExt === '.tid') {
+          this.logger.log(
+            `FileSystemWatcher Tiddler "${tiddlerTitle}" format restored from .json to .tid: ${actualFileAbsPath}`,
+          );
+        }
+      }
+
       // Store the file change info for later loading by syncer
       // Cache tiddler fields to avoid re-reading file in loadTiddler()
+      // IMPORTANT: Also cache fileDescriptor to preserve correct file format type.
+      // fileDescriptor.type is the FILE format type (e.g. 'application/x-tiddler' for .tid),
+      // NOT the tiddler's content type (e.g. 'text/markdown'). Using the wrong type
+      // causes saveTiddlerToFile() to save as JSON instead of .tid format.
       this.pendingFileLoads.set(tiddlerTitle, {
         absolutePath: actualFileAbsPath,
         relativePath: actualFileRelativePath,
         type: changeType,
         cachedTiddlerFields: tiddler,
+        cachedFileDescriptor: {
+          type: fileDescriptor.type as string | undefined,
+          hasMetaFile: fileDescriptor.hasMetaFile as boolean | undefined,
+          isEditableFile: fileDescriptor.isEditableFile as boolean | undefined,
+        },
       });
 
       // Update inverse index
@@ -726,6 +777,28 @@ export class FileSystemWatcher {
     const hasExcludedFileName = this.excludedFileNames.includes(fileName);
     const hasExternalAttachmentsFolder = pathParts.includes(this.externalAttachmentsFolder);
     return hasExcludedPattern || hasExcludedFileName || hasExternalAttachmentsFolder;
+  }
+
+  /**
+   * Infer the file format type from the file extension.
+   * This is used as a fallback when cachedFileDescriptor is not available.
+   *
+   * IMPORTANT: This returns the FILE FORMAT type (how to serialize), NOT the content type.
+   * - .tid → 'application/x-tiddler' (TiddlyWiki native format)
+   * - .json → 'application/json'
+   * - Other → 'application/x-tiddler' (safe default)
+   */
+  private inferFileTypeFromExtension(absolutePath: string): string {
+    const ext = path.extname(absolutePath).toLowerCase();
+    switch (ext) {
+      case '.json': {
+        return 'application/json';
+      }
+      case '.tid':
+      default: {
+        return 'application/x-tiddler';
+      }
+    }
   }
 
   private scheduleGitNotification(): void {

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
@@ -644,8 +644,8 @@ export class FileSystemWatcher {
         const wikiModified = (existingTiddler.fields.modified as string | undefined) ?? '';
         const fileText = (tiddler as { text?: string }).text ?? '';
         const wikiText = (existingTiddler.fields.text as string | undefined) ?? '';
-        // Normalize line endings and trim for robust comparison
-        const normalizeForCompare = (s: string) => s.replace(/\r\n/g, '\n').trim();
+        // Normalize line endings for robust comparison
+        const normalizeForCompare = (s: string) => s.replace(/\r\n/g, '\n');
         if (fileModified !== '' && fileModified === wikiModified && normalizeForCompare(fileText) === normalizeForCompare(wikiText)) {
           this.logger.log(`FileSystemWatcher Skipping self-echo for ${tiddlerTitle} (content identical)`);
           continue;
@@ -657,14 +657,14 @@ export class FileSystemWatcher {
       // saveTiddlerToFile() to save in the wrong format.
       const existingBootFile = this.boot.files[tiddlerTitle];
       if (existingBootFile?.filepath) {
-        const existingExt = path.extname(existingBootFile.filepath).toLowerCase();
-        const newExt = path.extname(actualFileAbsPath).toLowerCase();
-        if (existingExt === '.tid' && newExt === '.json') {
+        const existingExtension = path.extname(existingBootFile.filepath).toLowerCase();
+        const newExtension = path.extname(actualFileAbsPath).toLowerCase();
+        if (existingExtension === '.tid' && newExtension === '.json') {
           this.logger.alert(
             `FileSystemWatcher WARNING: Tiddler "${tiddlerTitle}" format changed from .tid to .json! `
             + `This may indicate a file format bug. Old: ${existingBootFile.filepath}, New: ${actualFileAbsPath}`,
           );
-        } else if (existingExt === '.json' && newExt === '.tid') {
+        } else if (existingExtension === '.json' && newExtension === '.tid') {
           this.logger.log(
             `FileSystemWatcher Tiddler "${tiddlerTitle}" format restored from .json to .tid: ${actualFileAbsPath}`,
           );
@@ -683,9 +683,9 @@ export class FileSystemWatcher {
         type: changeType,
         cachedTiddlerFields: tiddler,
         cachedFileDescriptor: {
-          type: fileDescriptor.type as string | undefined,
-          hasMetaFile: fileDescriptor.hasMetaFile as boolean | undefined,
-          isEditableFile: fileDescriptor.isEditableFile as boolean | undefined,
+          type: fileDescriptor.type ?? undefined,
+          hasMetaFile: fileDescriptor.hasMetaFile ?? undefined,
+          isEditableFile: fileDescriptor.isEditableFile ?? undefined,
         },
       });
 
@@ -789,8 +789,8 @@ export class FileSystemWatcher {
    * - Other → 'application/x-tiddler' (safe default)
    */
   private inferFileTypeFromExtension(absolutePath: string): string {
-    const ext = path.extname(absolutePath).toLowerCase();
-    switch (ext) {
+    const extension = path.extname(absolutePath).toLowerCase();
+    switch (extension) {
       case '.json': {
         return 'application/json';
       }

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemWatcher.ts
@@ -284,7 +284,9 @@ export class FileSystemWatcher {
       const { tiddlers: _, ...fileDescriptor } = tiddlersDescriptor;
       // Normalize to forward slashes for consistency with the inverse index and TiddlyWiki's path convention.
       const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
-      // Validate file type: ensure it's a recognized file format type, not a content type
+      // Use fileDescriptor.type (the file format type from $tw.loadTiddlersFromFile)
+      // rather than tiddler.type (the content type). Falls back to extension-based
+      // inference when fileDescriptor.type is unavailable.
       const fileType = (fileDescriptor.type as string) ?? this.inferFileTypeFromExtension(fileChange.absolutePath);
       this.boot.files[title] = {
         filepath: normalizedPath,

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Tests for FileSystemWatcher.loadTiddler() file format type preservation.
+ *
+ * This test suite verifies the fix for the bug where tiddlers would mysteriously
+ * change from .tid format to .json format on disk.
+ *
+ * Root cause: loadTiddler() was using the tiddler's content type (e.g. 'text/markdown')
+ * instead of the file format type (e.g. 'application/x-tiddler') when updating boot.files.
+ * This caused saveTiddlerToFile() to save as JSON instead of .tid format.
+ */
+import type { IFileInfo, Wiki } from 'tiddlywiki';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IFileChange } from '../FileSystemWatcher';
+
+// Mock TiddlyWiki global
+const mockLogger = {
+  log: vi.fn(),
+  alert: vi.fn(),
+};
+
+const mockUtils = {
+  Logger: vi.fn(() => mockLogger),
+  createDirectory: vi.fn(),
+};
+
+// Setup TiddlyWiki global
+// @ts-expect-error - Setting up global for testing
+global.$tw = {
+  node: true,
+  boot: {
+    wikiTiddlersPath: '/test/wiki/tiddlers',
+    wikiPath: '/test/wiki',
+    files: {} as Record<string, IFileInfo>,
+  },
+  utils: mockUtils,
+  syncer: null,
+};
+
+// Mock fs
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(() => false),
+    statSync: vi.fn(() => ({ mtimeMs: 1000, size: 100 })),
+    readFile: vi.fn(),
+    readFileSync: vi.fn(),
+  },
+  existsSync: vi.fn(() => false),
+  statSync: vi.fn(() => ({ mtimeMs: 1000, size: 100 })),
+}));
+
+// Mock nsfw
+vi.mock('nsfw', () => ({
+  default: vi.fn().mockResolvedValue({
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+  actions: {
+    CREATED: 0,
+    DELETED: 1,
+    MODIFIED: 2,
+    RENAMED: 3,
+  },
+}));
+
+// Mock workspace service
+vi.mock('@services/wiki/wikiWorker/services', () => ({
+  workspace: {
+    get: vi.fn(),
+    getSubWorkspacesAsList: vi.fn().mockResolvedValue([]),
+  },
+  git: {
+    notifyFileChange: vi.fn(),
+  },
+}));
+
+describe('FileSystemWatcher - loadTiddler file format type preservation', () => {
+  let mockWiki: Wiki;
+  let mockBoot: typeof $tw.boot;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockBoot = {
+      wikiTiddlersPath: '/test/wiki/tiddlers',
+      wikiPath: '/test/wiki',
+      files: {} as Record<string, IFileInfo>,
+    } as unknown as typeof $tw.boot;
+
+    mockWiki = {
+      getTiddlerText: vi.fn((title: string) => {
+        if (title === '$:/info/tidgi/useWikiFolderAsTiddlersPath') return 'no';
+        return '';
+      }),
+      tiddlerExists: vi.fn(() => false),
+      getTiddler: vi.fn(() => undefined),
+    } as unknown as Wiki;
+  });
+
+  describe('Type preservation with cached tiddler fields', () => {
+    it('should use fileDescriptor.type (application/x-tiddler) not tiddler.type (text/markdown) for .tid files', () => {
+      // Simulate a .tid file containing a markdown tiddler
+      const fileChange: IFileChange = {
+        absolutePath: '/test/wiki/tiddlers/my-note.tid',
+        relativePath: 'my-note.tid',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'My Note',
+          text: '# Hello World',
+          type: 'text/markdown', // Tiddler's content type
+          modified: '20250101120000000',
+        },
+        cachedFileDescriptor: {
+          type: 'application/x-tiddler', // File format type (correct!)
+          hasMetaFile: false,
+          isEditableFile: true,
+        },
+      };
+
+      // Simulate what loadTiddler does with cached fields
+      const title = 'My Note';
+      const hasMetaFile = false;
+      const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
+
+      // The FIXED code: use cachedFileDescriptor.type
+      const fileType = fileChange.cachedFileDescriptor?.type ?? 'application/x-tiddler';
+
+      const bootFileEntry = {
+        filepath: normalizedPath,
+        type: fileType,
+        hasMetaFile: fileChange.cachedFileDescriptor?.hasMetaFile ?? hasMetaFile,
+        isEditableFile: fileChange.cachedFileDescriptor?.isEditableFile ?? true,
+      };
+
+      // Verify the type is the file format type, not the content type
+      expect(bootFileEntry.type).toBe('application/x-tiddler');
+      expect(bootFileEntry.type).not.toBe('text/markdown');
+    });
+
+    it('should use application/json type for .json files', () => {
+      const fileChange: IFileChange = {
+        absolutePath: '/test/wiki/tiddlers/my-data.json',
+        relativePath: 'my-data.json',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'My Data',
+          text: '{"key": "value"}',
+          type: 'application/json',
+          modified: '20250101120000000',
+        },
+        cachedFileDescriptor: {
+          type: 'application/json',
+          hasMetaFile: false,
+          isEditableFile: true,
+        },
+      };
+
+      const fileType = fileChange.cachedFileDescriptor?.type ?? 'application/x-tiddler';
+      expect(fileType).toBe('application/json');
+    });
+
+    it('should fall back to extension-based inference when cachedFileDescriptor is missing', () => {
+      const fileChange: IFileChange = {
+        absolutePath: '/test/wiki/tiddlers/my-note.tid',
+        relativePath: 'my-note.tid',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'My Note',
+          text: '# Hello',
+          type: 'text/markdown',
+        },
+        // No cachedFileDescriptor!
+      };
+
+      // Simulate inferFileTypeFromExtension
+      const ext = '.tid';
+      const inferFileType = (ext: string): string => {
+        switch (ext) {
+          case '.json': return 'application/json';
+          case '.tid':
+          default: return 'application/x-tiddler';
+        }
+      };
+
+      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(ext);
+      expect(fileType).toBe('application/x-tiddler');
+    });
+
+    it('should infer application/json for .json extension when cachedFileDescriptor is missing', () => {
+      const fileChange: IFileChange = {
+        absolutePath: '/test/wiki/tiddlers/data.json',
+        relativePath: 'data.json',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'Data',
+          text: '{}',
+          type: 'application/json',
+        },
+      };
+
+      const ext = '.json';
+      const inferFileType = (ext: string): string => {
+        switch (ext) {
+          case '.json': return 'application/json';
+          case '.tid':
+          default: return 'application/x-tiddler';
+        }
+      };
+
+      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(ext);
+      expect(fileType).toBe('application/json');
+    });
+  });
+
+  describe('BUG SCENARIO: .tid file with non-standard content type', () => {
+    it('should NOT change .tid to .json when tiddler has type text/markdown', () => {
+      // This is the exact scenario from the bug report:
+      // 1. Tiddler saved as .tid (type: 'text/markdown')
+      // 2. Watcher detects change, loads file
+      // 3. fileDescriptor.type = 'application/x-tiddler' (correct)
+      // 4. tiddler.type = 'text/markdown' (content type)
+      // 5. OLD BUG: boot.files[title].type = 'text/markdown' → next save = JSON!
+      // 6. FIX: boot.files[title].type = 'application/x-tiddler' → next save = .tid ✓
+
+      const fileDescriptorType = 'application/x-tiddler';
+      const tiddlerContentType = 'text/markdown';
+
+      // OLD (buggy) code would use:
+      const oldFileType = tiddlerContentType ?? 'application/x-tiddler';
+      expect(oldFileType).toBe('text/markdown'); // BUG! This causes JSON format
+
+      // NEW (fixed) code uses:
+      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
+      expect(newFileType).toBe('application/x-tiddler'); // CORRECT! This preserves .tid format
+    });
+
+    it('should NOT change .tid to .json when tiddler has type text/plain', () => {
+      const fileDescriptorType = 'application/x-tiddler';
+      const tiddlerContentType = 'text/plain';
+
+      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
+      expect(newFileType).toBe('application/x-tiddler');
+    });
+
+    it('should NOT change .tid to .json when tiddler has type image/png (with .meta)', () => {
+      // For binary tiddlers with .meta files, the file format is still 'application/x-tiddler'
+      // or the tiddler type itself, but with hasMetaFile = true
+      const fileDescriptorType = 'image/png';
+      const hasMetaFile = true;
+
+      // With .meta file, the body file uses the tiddler type for encoding
+      // but the file format decision is based on hasMetaFile, not type
+      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
+      expect(newFileType).toBe('image/png');
+      expect(hasMetaFile).toBe(true); // Body + .meta file format
+    });
+  });
+});

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
@@ -74,19 +74,11 @@ vi.mock('@services/wiki/wikiWorker/services', () => ({
 }));
 
 describe('FileSystemWatcher - loadTiddler file format type preservation', () => {
-  let mockWiki: Wiki;
-  let mockBoot: typeof $tw.boot;
-
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockBoot = {
-      wikiTiddlersPath: '/test/wiki/tiddlers',
-      wikiPath: '/test/wiki',
-      files: {} as Record<string, IFileInfo>,
-    } as unknown as typeof $tw.boot;
-
-    mockWiki = {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _mockWiki = {
       getTiddlerText: vi.fn((title: string) => {
         if (title === '$:/info/tidgi/useWikiFolderAsTiddlersPath') return 'no';
         return '';
@@ -117,8 +109,6 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       };
 
       // Simulate what loadTiddler does with cached fields
-      const title = 'My Note';
-      const hasMetaFile = false;
       const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
 
       // The FIXED code: use cachedFileDescriptor.type
@@ -127,7 +117,7 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       const bootFileEntry = {
         filepath: normalizedPath,
         type: fileType,
-        hasMetaFile: fileChange.cachedFileDescriptor?.hasMetaFile ?? hasMetaFile,
+        hasMetaFile: fileChange.cachedFileDescriptor?.hasMetaFile ?? false,
         isEditableFile: fileChange.cachedFileDescriptor?.isEditableFile ?? true,
       };
 
@@ -172,7 +162,7 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       };
 
       // Simulate inferFileTypeFromExtension
-      const ext = '.tid';
+      const extension = '.tid';
       const inferFileType = (ext: string): string => {
         switch (ext) {
           case '.json': return 'application/json';
@@ -181,7 +171,7 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
         }
       };
 
-      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(ext);
+      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(extension);
       expect(fileType).toBe('application/x-tiddler');
     });
 
@@ -197,7 +187,7 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
         },
       };
 
-      const ext = '.json';
+      const extension = '.json';
       const inferFileType = (ext: string): string => {
         switch (ext) {
           case '.json': return 'application/json';
@@ -206,7 +196,7 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
         }
       };
 
-      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(ext);
+      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(extension);
       expect(fileType).toBe('application/json');
     });
   });
@@ -222,20 +212,18 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       // 6. FIX: boot.files[title].type = 'application/x-tiddler' → next save = .tid ✓
 
       const fileDescriptorType = 'application/x-tiddler';
-      const tiddlerContentType = 'text/markdown';
 
-      // OLD (buggy) code would use:
-      const oldFileType = tiddlerContentType ?? 'application/x-tiddler';
-      expect(oldFileType).toBe('text/markdown'); // BUG! This causes JSON format
+      // Demonstrate the bug: using tiddler content type instead of file format type
+      // would cause saveTiddlerToFile() to save as JSON
+      expect('text/markdown').not.toBe('application/x-tiddler'); // Different types!
 
-      // NEW (fixed) code uses:
+      // NEW (fixed) code uses file format type:
       const newFileType = fileDescriptorType ?? 'application/x-tiddler';
       expect(newFileType).toBe('application/x-tiddler'); // CORRECT! This preserves .tid format
     });
 
     it('should NOT change .tid to .json when tiddler has type text/plain', () => {
       const fileDescriptorType = 'application/x-tiddler';
-      const tiddlerContentType = 'text/plain';
 
       const newFileType = fileDescriptorType ?? 'application/x-tiddler';
       expect(newFileType).toBe('application/x-tiddler');

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
@@ -10,7 +10,7 @@
  */
 import type { IFileInfo, Wiki } from 'tiddlywiki';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { IFileChange } from '../FileSystemWatcher';
+import { FileSystemWatcher, type IFileChange } from '../FileSystemWatcher';
 
 // Mock TiddlyWiki global
 const mockLogger = {
@@ -74,10 +74,16 @@ vi.mock('@services/wiki/wikiWorker/services', () => ({
 }));
 
 describe('FileSystemWatcher - loadTiddler file format type preservation', () => {
+  let watcher: FileSystemWatcher;
+  let mockWiki: Wiki;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
-    const _mockWiki = {
+    // @ts-expect-error - Setting up global for testing
+    global.$tw.boot.files = {};
+
+    mockWiki = {
       getTiddlerText: vi.fn((title: string) => {
         if (title === '$:/info/tidgi/useWikiFolderAsTiddlersPath') return 'no';
         return '';
@@ -85,12 +91,36 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       tiddlerExists: vi.fn(() => false),
       getTiddler: vi.fn(() => undefined),
     } as unknown as Wiki;
+
+    watcher = new FileSystemWatcher({
+      wiki: mockWiki,
+      // @ts-expect-error - Setting up global for testing
+      boot: global.$tw.boot,
+      logger: mockLogger as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      workspaceID: 'test-workspace',
+    });
   });
+
+  /**
+   * Helper to inject a pendingFileLoads entry and call loadTiddler.
+   * Returns the boot.files entry that was set by loadTiddler.
+   */
+  function injectAndLoad(fileChange: IFileChange): IFileInfo {
+    // Inject the file change into pendingFileLoads
+    (watcher as any).pendingFileLoads.set(fileChange.cachedTiddlerFields?.title ?? 'Test', fileChange); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const title = fileChange.cachedTiddlerFields?.title as string;
+    let result: IFileInfo | null = null;
+    watcher.loadTiddler(title, (_err, _fields) => {
+      // loadTiddler sets boot.files[title] as a side effect
+      result = (global.$tw.boot.files as Record<string, IFileInfo>)[title];
+    });
+    return result!;
+  }
 
   describe('Type preservation with cached tiddler fields', () => {
     it('should use fileDescriptor.type (application/x-tiddler) not tiddler.type (text/markdown) for .tid files', () => {
-      // Simulate a .tid file containing a markdown tiddler
-      const fileChange: IFileChange = {
+      const bootFileInfo = injectAndLoad({
         absolutePath: '/test/wiki/tiddlers/my-note.tid',
         relativePath: 'my-note.tid',
         type: 'change',
@@ -105,28 +135,15 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
           hasMetaFile: false,
           isEditableFile: true,
         },
-      };
+      });
 
-      // Simulate what loadTiddler does with cached fields
-      const normalizedPath = fileChange.absolutePath.replace(/\\/g, '/');
-
-      // The FIXED code: use cachedFileDescriptor.type
-      const fileType = fileChange.cachedFileDescriptor?.type ?? 'application/x-tiddler';
-
-      const bootFileEntry = {
-        filepath: normalizedPath,
-        type: fileType,
-        hasMetaFile: fileChange.cachedFileDescriptor?.hasMetaFile ?? false,
-        isEditableFile: fileChange.cachedFileDescriptor?.isEditableFile ?? true,
-      };
-
-      // Verify the type is the file format type, not the content type
-      expect(bootFileEntry.type).toBe('application/x-tiddler');
-      expect(bootFileEntry.type).not.toBe('text/markdown');
+      // Verify loadTiddler set the file format type, not the content type
+      expect(bootFileInfo.type).toBe('application/x-tiddler');
+      expect(bootFileInfo.type).not.toBe('text/markdown');
     });
 
     it('should use application/json type for .json files', () => {
-      const fileChange: IFileChange = {
+      const bootFileInfo = injectAndLoad({
         absolutePath: '/test/wiki/tiddlers/my-data.json',
         relativePath: 'my-data.json',
         type: 'change',
@@ -141,14 +158,13 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
           hasMetaFile: false,
           isEditableFile: true,
         },
-      };
+      });
 
-      const fileType = fileChange.cachedFileDescriptor?.type ?? 'application/x-tiddler';
-      expect(fileType).toBe('application/json');
+      expect(bootFileInfo.type).toBe('application/json');
     });
 
     it('should fall back to extension-based inference when cachedFileDescriptor is missing', () => {
-      const fileChange: IFileChange = {
+      const bootFileInfo = injectAndLoad({
         absolutePath: '/test/wiki/tiddlers/my-note.tid',
         relativePath: 'my-note.tid',
         type: 'change',
@@ -158,26 +174,14 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
           type: 'text/markdown',
         },
         // No cachedFileDescriptor!
-      };
+      });
 
-      // Simulate inferFileTypeFromExtension
-      const extension = '.tid';
-      const inferFileType = (ext: string): string => {
-        switch (ext) {
-          case '.json':
-            return 'application/json';
-          case '.tid':
-          default:
-            return 'application/x-tiddler';
-        }
-      };
-
-      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(extension);
-      expect(fileType).toBe('application/x-tiddler');
+      // Should infer application/x-tiddler from .tid extension
+      expect(bootFileInfo.type).toBe('application/x-tiddler');
     });
 
     it('should infer application/json for .json extension when cachedFileDescriptor is missing', () => {
-      const fileChange: IFileChange = {
+      const bootFileInfo = injectAndLoad({
         absolutePath: '/test/wiki/tiddlers/data.json',
         relativePath: 'data.json',
         type: 'change',
@@ -186,21 +190,9 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
           text: '{}',
           type: 'application/json',
         },
-      };
+      });
 
-      const extension = '.json';
-      const inferFileType = (ext: string): string => {
-        switch (ext) {
-          case '.json':
-            return 'application/json';
-          case '.tid':
-          default:
-            return 'application/x-tiddler';
-        }
-      };
-
-      const fileType = fileChange.cachedFileDescriptor?.type ?? inferFileType(extension);
-      expect(fileType).toBe('application/json');
+      expect(bootFileInfo.type).toBe('application/json');
     });
   });
 
@@ -213,36 +205,64 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       // 4. tiddler.type = 'text/markdown' (content type)
       // 5. OLD BUG: boot.files[title].type = 'text/markdown' → next save = JSON!
       // 6. FIX: boot.files[title].type = 'application/x-tiddler' → next save = .tid ✓
+      const bootFileInfo = injectAndLoad({
+        absolutePath: '/test/wiki/tiddlers/my-note.tid',
+        relativePath: 'my-note.tid',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'My Note',
+          text: '# Hello',
+          type: 'text/markdown',
+        },
+        cachedFileDescriptor: {
+          type: 'application/x-tiddler',
+          hasMetaFile: false,
+          isEditableFile: true,
+        },
+      });
 
-      const fileDescriptorType = 'application/x-tiddler';
-
-      // Demonstrate the bug: using tiddler content type instead of file format type
-      // would cause saveTiddlerToFile() to save as JSON
-      expect('text/markdown').not.toBe('application/x-tiddler'); // Different types!
-
-      // NEW (fixed) code uses file format type:
-      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
-      expect(newFileType).toBe('application/x-tiddler'); // CORRECT! This preserves .tid format
+      expect(bootFileInfo.type).toBe('application/x-tiddler');
+      expect(bootFileInfo.type).not.toBe('text/markdown');
     });
 
     it('should NOT change .tid to .json when tiddler has type text/plain', () => {
-      const fileDescriptorType = 'application/x-tiddler';
+      const bootFileInfo = injectAndLoad({
+        absolutePath: '/test/wiki/tiddlers/plain-note.tid',
+        relativePath: 'plain-note.tid',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'Plain Note',
+          text: 'Just plain text',
+          type: 'text/plain',
+        },
+        cachedFileDescriptor: {
+          type: 'application/x-tiddler',
+          hasMetaFile: false,
+          isEditableFile: true,
+        },
+      });
 
-      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
-      expect(newFileType).toBe('application/x-tiddler');
+      expect(bootFileInfo.type).toBe('application/x-tiddler');
     });
 
-    it('should NOT change .tid to .json when tiddler has type image/png (with .meta)', () => {
-      // For binary tiddlers with .meta files, the file format is still 'application/x-tiddler'
-      // or the tiddler type itself, but with hasMetaFile = true
-      const fileDescriptorType = 'image/png';
-      const hasMetaFile = true;
+    it('should preserve image/png type for binary tiddlers with .meta', () => {
+      const bootFileInfo = injectAndLoad({
+        absolutePath: '/test/wiki/tiddlers/photo.png',
+        relativePath: 'photo.png',
+        type: 'change',
+        cachedTiddlerFields: {
+          title: 'photo.png',
+          type: 'image/png',
+        },
+        cachedFileDescriptor: {
+          type: 'image/png',
+          hasMetaFile: true,
+          isEditableFile: true,
+        },
+      });
 
-      // With .meta file, the body file uses the tiddler type for encoding
-      // but the file format decision is based on hasMetaFile, not type
-      const newFileType = fileDescriptorType ?? 'application/x-tiddler';
-      expect(newFileType).toBe('image/png');
-      expect(hasMetaFile).toBe(true); // Body + .meta file format
+      expect(bootFileInfo.type).toBe('image/png');
+      expect(bootFileInfo.hasMetaFile).toBe(true);
     });
   });
 });

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemWatcher.loadTiddler.test.ts
@@ -77,7 +77,6 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _mockWiki = {
       getTiddlerText: vi.fn((title: string) => {
         if (title === '$:/info/tidgi/useWikiFolderAsTiddlersPath') return 'no';
@@ -165,9 +164,11 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       const extension = '.tid';
       const inferFileType = (ext: string): string => {
         switch (ext) {
-          case '.json': return 'application/json';
+          case '.json':
+            return 'application/json';
           case '.tid':
-          default: return 'application/x-tiddler';
+          default:
+            return 'application/x-tiddler';
         }
       };
 
@@ -190,9 +191,11 @@ describe('FileSystemWatcher - loadTiddler file format type preservation', () => 
       const extension = '.json';
       const inferFileType = (ext: string): string => {
         switch (ext) {
-          case '.json': return 'application/json';
+          case '.json':
+            return 'application/json';
           case '.tid':
-          default: return 'application/x-tiddler';
+          default:
+            return 'application/x-tiddler';
         }
       };
 

--- a/src/services/workspacesView/index.ts
+++ b/src/services/workspacesView/index.ts
@@ -58,6 +58,20 @@ export class WorkspaceView implements IWorkspaceViewService {
     await mapSeries(sortedList, async (workspace) => {
       await this.initializeWorkspaceView(workspace);
     });
+
+    // After all main workspaces have resolved their hibernated state,
+    // sync sub-workspaces to match their main workspace.
+    // Sub-workspaces have no wiki service, no view, and no independent behavior —
+    // their hibernated flag is purely a UI indicator that must follow the main workspace.
+    for (const workspace of workspacesList) {
+      if (!isWikiWorkspace(workspace) || !workspace.isSubWiki || typeof workspace.mainWikiID !== 'string') continue;
+      const mainWorkspace = await workspaceService.get(workspace.mainWikiID);
+      if (mainWorkspace === undefined || !isWikiWorkspace(mainWorkspace)) continue;
+      if (mainWorkspace.hibernated !== workspace.hibernated) {
+        await workspaceService.update(workspace.id, { hibernated: mainWorkspace.hibernated });
+      }
+    }
+
     wikiService.setAllWikiStartLockOff();
   }
 
@@ -103,6 +117,13 @@ export class WorkspaceView implements IWorkspaceViewService {
     });
     if (followHibernateSettingWhenInit) {
       const hibernateUnusedWorkspacesAtLaunch = await this.preferenceService.get('hibernateUnusedWorkspacesAtLaunch');
+
+      // Sub-workspaces have no wiki service, no view, and no independent behavior.
+      // Their hibernated state is synced in initializeAllWorkspaceView after main workspaces are resolved.
+      if (isWikiWorkspace(workspace) && workspace.isSubWiki) {
+        return;
+      }
+
       if ((hibernateUnusedWorkspacesAtLaunch || (isWikiWorkspace(workspace) && workspace.hibernateWhenUnused)) && !workspace.active) {
         logger.debug(
           `initializeWorkspaceView() quit because ${

--- a/src/services/workspacesView/index.ts
+++ b/src/services/workspacesView/index.ts
@@ -316,12 +316,21 @@ export class WorkspaceView implements IWorkspaceViewService {
   public async wakeUpWorkspaceView(workspaceID: string): Promise<void> {
     const workspace = await container.get<IWorkspaceService>(serviceIdentifier.Workspace).get(workspaceID);
     if (workspace !== undefined) {
+      const workspaceService = container.get<IWorkspaceService>(serviceIdentifier.Workspace);
+
+      // Also update sub-workspaces hibernated state so their icons restore together with the main workspace.
+      // Sub-workspaces don't have their own wiki service or views — they share the main workspace's,
+      // so only the UI flag needs to be updated.
+      const subWorkspaces = await workspaceService.getSubWorkspacesAsList(workspaceID);
+      const hibernatedSubWorkspaces = subWorkspaces.filter(sw => sw.hibernated);
+
       // First, update workspace state and start wiki server
       await Promise.all([
-        container.get<IWorkspaceService>(serviceIdentifier.Workspace).update(workspaceID, {
-          hibernated: false,
-        }),
+        workspaceService.update(workspaceID, { hibernated: false }),
         this.authService.getUserName(workspace).then(userName => container.get<IWikiService>(serviceIdentifier.Wiki).startWiki(workspaceID, userName)),
+        ...hibernatedSubWorkspaces.map(async (subWorkspace) => {
+          await workspaceService.update(subWorkspace.id, { hibernated: false });
+        }),
       ]);
 
       // Then add view after wiki server is ready and workspace is marked as not hibernated
@@ -337,10 +346,19 @@ export class WorkspaceView implements IWorkspaceViewService {
       active: String(workspace?.active),
     });
     if (workspace !== undefined && !workspace.active) {
+      const workspaceService = container.get<IWorkspaceService>(serviceIdentifier.Workspace);
+
+      // Also update sub-workspaces hibernated state so their icons turn gray together with the main workspace.
+      // Sub-workspaces don't have their own wiki service or views — they share the main workspace's,
+      // so only the UI flag needs to be updated.
+      const subWorkspaces = await workspaceService.getSubWorkspacesAsList(workspaceID);
+      const subWorkspaceIDs = subWorkspaces.filter(sw => !sw.active).map(sw => sw.id);
+
       await Promise.all([
         container.get<IWikiService>(serviceIdentifier.Wiki).stopWiki(workspaceID),
-        container.get<IWorkspaceService>(serviceIdentifier.Workspace).update(workspaceID, {
-          hibernated: true,
+        workspaceService.update(workspaceID, { hibernated: true }),
+        ...subWorkspaceIDs.map(async (subID) => {
+          await workspaceService.update(subID, { hibernated: true });
         }),
       ]);
       container.get<IViewService>(serviceIdentifier.View).destroyAllViewsOfWorkspace(workspaceID);

--- a/src/windows/GitLog/CommitDetailsPanel.tsx
+++ b/src/windows/GitLog/CommitDetailsPanel.tsx
@@ -18,6 +18,7 @@ import Typography from '@mui/material/Typography';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { SupportedStorageServices } from '@services/types';
 import { getFileStatusStyles, type GitFileStatus } from './fileStatusStyles';
 import type { GitLogEntry } from './types';
 
@@ -74,6 +75,7 @@ interface ICommitDetailsPanelProps {
   commit: GitLogEntry | null;
   isLatestCommit?: boolean;
   workspaceID: string;
+  storageService: import('@services/types').SupportedStorageServices;
   onCommitSuccess?: () => void;
   showSnackbar?: (message: string, severity?: 'success' | 'error' | 'info') => void;
   onFileSelect?: (file: string | null, event?: React.MouseEvent) => void;
@@ -89,6 +91,7 @@ export function CommitDetailsPanel(
     commit,
     isLatestCommit: _isLatestCommit,
     workspaceID,
+    storageService,
     onCommitSuccess,
     showSnackbar,
     onFileSelect,
@@ -539,7 +542,7 @@ export function CommitDetailsPanel(
 
           {!isUncommitted && (
             <>
-              {!hasMultipleCommitsSelected && commit.isUnpushed && (
+              {!hasMultipleCommitsSelected && commit.isUnpushed && storageService !== SupportedStorageServices.local && (
                 <Button
                   variant='contained'
                   color='warning'

--- a/src/windows/GitLog/GitLogSyncSettings.tsx
+++ b/src/windows/GitLog/GitLogSyncSettings.tsx
@@ -1,0 +1,82 @@
+import { Button, Divider, List, styled } from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ListItem } from '@/components/ListItem';
+import { TokenForm } from '@/components/TokenForm';
+import { SupportedStorageServices } from '@services/types';
+import { type IWikiWorkspace } from '@services/workspaces/interface';
+import { GitRepoUrlForm } from '../AddWorkspace/GitRepoUrlForm';
+import { SyncedWikiDescription } from '../AddWorkspace/Description';
+
+const SettingsContainer = styled('div')`
+  padding: 16px;
+  overflow-y: auto;
+  height: 100%;
+`;
+
+interface IGitLogSyncSettingsProps {
+  workspace: IWikiWorkspace;
+  onSaved?: () => void;
+}
+
+export function GitLogSyncSettings({ workspace, onSaved }: IGitLogSyncSettingsProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [storageService, setStorageService] = useState(workspace.storageService);
+  const [gitUrl, setGitUrl] = useState(workspace.gitUrl ?? '');
+
+  useEffect(() => {
+    setStorageService(workspace.storageService);
+    setGitUrl(workspace.gitUrl ?? '');
+  }, [workspace.storageService, workspace.gitUrl]);
+
+  const handleSave = useCallback(async () => {
+    await window.service.workspace.update(workspace.id, {
+      storageService,
+      gitUrl,
+    });
+    onSaved?.();
+  }, [workspace.id, storageService, gitUrl, onSaved]);
+
+  const isSyncedWorkspace = storageService !== SupportedStorageServices.local;
+
+  return (
+    <SettingsContainer>
+      <List dense>
+        <ListItem>
+          <SyncedWikiDescription
+            isCreateSyncedWorkspace={isSyncedWorkspace}
+            isCreateSyncedWorkspaceSetter={(isSynced) => {
+              setStorageService(isSynced ? SupportedStorageServices.github : SupportedStorageServices.local);
+            }}
+          />
+        </ListItem>
+
+        {isSyncedWorkspace && (
+          <>
+            <Divider sx={{ my: 1 }} />
+            <ListItem>
+              <TokenForm
+                storageProvider={storageService}
+                storageProviderSetter={setStorageService}
+              />
+            </ListItem>
+            <Divider sx={{ my: 1 }} />
+            <ListItem>
+              <GitRepoUrlForm
+                storageProvider={storageService}
+                gitRepoUrl={gitUrl}
+                gitRepoUrlSetter={setGitUrl}
+                isCreateMainWorkspace={!workspace.isSubWiki}
+              />
+            </ListItem>
+          </>
+        )}
+      </List>
+
+      <Button variant='contained' onClick={handleSave} fullWidth sx={{ mt: 2 }}>
+        {t('EditWorkspace.Save')}
+      </Button>
+    </SettingsContainer>
+  );
+}

--- a/src/windows/GitLog/GitLogSyncSettings.tsx
+++ b/src/windows/GitLog/GitLogSyncSettings.tsx
@@ -6,8 +6,8 @@ import { ListItem } from '@/components/ListItem';
 import { TokenForm } from '@/components/TokenForm';
 import { SupportedStorageServices } from '@services/types';
 import { type IWikiWorkspace } from '@services/workspaces/interface';
-import { GitRepoUrlForm } from '../AddWorkspace/GitRepoUrlForm';
 import { SyncedWikiDescription } from '../AddWorkspace/Description';
+import { GitRepoUrlForm } from '../AddWorkspace/GitRepoUrlForm';
 
 const SettingsContainer = styled('div')`
   padding: 16px;

--- a/src/windows/GitLog/index.tsx
+++ b/src/windows/GitLog/index.tsx
@@ -338,9 +338,7 @@ export default function GitHistory(): React.JSX.Element {
                 renderTooltip={renderTooltip}
               />
             )}
-            {viewMode === 'syncSettings' && workspaceInfo && 'wikiFolderLocation' in workspaceInfo && (
-              <GitLogSyncSettings workspace={workspaceInfo as unknown as import('@services/workspaces/interface').IWikiWorkspace} />
-            )}
+            {viewMode === 'syncSettings' && workspaceInfo && 'wikiFolderLocation' in workspaceInfo && <GitLogSyncSettings workspace={workspaceInfo} />}
           </TabContent>
         </GitLogWrapper>
         <DetailsWrapper>
@@ -353,36 +351,36 @@ export default function GitHistory(): React.JSX.Element {
               </DetailsPanelWrapper>
             )
             : workspaceInfo
-              ? (
-                <DetailsPanelWrapper>
-                  <CommitDetailsPanel
-                    commit={selectedCommit ?? null}
-                    selectedCommits={selectedCommits}
-                    workspaceID={workspaceInfo.id}
-                    storageService={'storageService' in workspaceInfo ? workspaceInfo.storageService : SupportedStorageServices.local}
-                    showSnackbar={showSnackbar}
-                    onFileSelect={handleFileSelect}
-                    selectedFile={selectedFile}
-                    selectedFiles={selectedFiles}
-                    onCommitSuccess={handleCommitSuccess}
-                    onRevertSuccess={handleRevertSuccess}
-                    onUndoSuccess={handleUndoSuccess}
-                    isLatestCommit={selectedCommit?.hash === entries.find((entry) => entry.hash !== '')?.hash}
-                  />
-                </DetailsPanelWrapper>
-              )
-              : (
-                <DetailsPanelWrapper
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                  }}
-                >
-                  <CircularProgress />
-                </DetailsPanelWrapper>
-              )}
+            ? (
+              <DetailsPanelWrapper>
+                <CommitDetailsPanel
+                  commit={selectedCommit ?? null}
+                  selectedCommits={selectedCommits}
+                  workspaceID={workspaceInfo.id}
+                  storageService={'storageService' in workspaceInfo ? workspaceInfo.storageService : SupportedStorageServices.local}
+                  showSnackbar={showSnackbar}
+                  onFileSelect={handleFileSelect}
+                  selectedFile={selectedFile}
+                  selectedFiles={selectedFiles}
+                  onCommitSuccess={handleCommitSuccess}
+                  onRevertSuccess={handleRevertSuccess}
+                  onUndoSuccess={handleUndoSuccess}
+                  isLatestCommit={selectedCommit?.hash === entries.find((entry) => entry.hash !== '')?.hash}
+                />
+              </DetailsPanelWrapper>
+            )
+            : (
+              <DetailsPanelWrapper
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '100%',
+                }}
+              >
+                <CircularProgress />
+              </DetailsPanelWrapper>
+            )}
         </DetailsWrapper>
 
         <DiffPanelWrapper>
@@ -395,29 +393,29 @@ export default function GitHistory(): React.JSX.Element {
               </Box>
             )
             : workspaceInfo
-              ? (
-                <FileDiffPanel
-                  commitHash={selectedCommit?.hash || ''}
-                  filePath={selectedFile}
-                  selectedFiles={selectedFiles}
-                  workspaceID={workspaceInfo.id}
-                  onDiscardSuccess={handleFileActionSuccess}
-                  showSnackbar={showSnackbar}
-                />
-              )
-              : (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                    width: '100%',
-                  }}
-                >
-                  <CircularProgress />
-                </Box>
-              )}
+            ? (
+              <FileDiffPanel
+                commitHash={selectedCommit?.hash || ''}
+                filePath={selectedFile}
+                selectedFiles={selectedFiles}
+                workspaceID={workspaceInfo.id}
+                onDiscardSuccess={handleFileActionSuccess}
+                showSnackbar={showSnackbar}
+              />
+            )
+            : (
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '100%',
+                  width: '100%',
+                }}
+              >
+                <CircularProgress />
+              </Box>
+            )}
         </DiffPanelWrapper>
       </ContentWrapper>
 

--- a/src/windows/GitLog/index.tsx
+++ b/src/windows/GitLog/index.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { SupportedStorageServices } from '@services/types';
 import { WindowNames } from '@services/windows/WindowProperties';
 import type { WindowMeta } from '@services/windows/WindowProperties';
 import { AllBranchesView } from './AllBranchesView';
@@ -17,6 +18,7 @@ import { CommitDetailsPanel } from './CommitDetailsPanel';
 import { CurrentBranchView } from './CurrentBranchView';
 import { CustomGitTooltip } from './CustomGitTooltip';
 import { FileDiffPanel } from './FileDiffPanel';
+import { GitLogSyncSettings } from './GitLogSyncSettings';
 import { ContentWrapper, DetailsPanelWrapper, DetailsWrapper, DiffPanelWrapper, GitLogWrapper, LoadingContainer, Root, TabContent, TabsContainer } from './styles';
 import { useCommitDetails } from './useCommitDetails';
 import { useCommitSelection, useGitHistoryState, useInfiniteScroll, useSyncHandler } from './useGitHistoryLogic';
@@ -296,106 +298,126 @@ export default function GitHistory(): React.JSX.Element {
           <TabsContainer>
             <Tabs
               value={viewMode}
-              onChange={(_event, newValue: 'current' | 'all') => {
+              onChange={(_event, newValue: 'current' | 'all' | 'syncSettings') => {
                 setViewMode(newValue);
               }}
             >
               <Tab label={currentBranch || 'master'} value='current' />
               <Tab label={t('GitLog.AllBranches')} value='all' />
+              <Tab label={t('GitLog.SyncSettings')} value='syncSettings' />
             </Tabs>
           </TabsContainer>
 
           <TabContent>
-            {viewMode === 'current'
-              ? (
-                <CurrentBranchView
-                  entries={entries}
-                  loading={loading}
-                  loadingMore={loadingMore}
-                  hasMore={hasMore}
-                  selectedCommitHashes={selectedCommitHashes}
-                  currentSearchParameters={currentSearchParameters}
-                  onSearch={handleSearch}
-                  onSelectCommit={handleCommitClick}
-                  onSyncClick={handleSyncClick}
-                  isRowLoaded={isRowLoaded}
-                  loadMoreRows={loadMoreRows}
-                />
-              )
-              : (
-                <AllBranchesView
-                  entries={entries}
-                  currentBranch={currentBranch}
-                  theme={gitLogTheme}
-                  onSelectCommit={(entry) => {
-                    setSelectedCommit(entry);
-                    setSelectedCommitHashes([entry.hash]);
-                    setCommitSelectionAnchorHash(entry.hash);
-                    setSelectedFile(null);
-                  }}
-                  renderTooltip={renderTooltip}
-                />
-              )}
+            {viewMode === 'current' && (
+              <CurrentBranchView
+                entries={entries}
+                loading={loading}
+                loadingMore={loadingMore}
+                hasMore={hasMore}
+                selectedCommitHashes={selectedCommitHashes}
+                currentSearchParameters={currentSearchParameters}
+                onSearch={handleSearch}
+                onSelectCommit={handleCommitClick}
+                onSyncClick={handleSyncClick}
+                isRowLoaded={isRowLoaded}
+                loadMoreRows={loadMoreRows}
+              />
+            )}
+            {viewMode === 'all' && (
+              <AllBranchesView
+                entries={entries}
+                currentBranch={currentBranch}
+                theme={gitLogTheme}
+                onSelectCommit={(entry) => {
+                  setSelectedCommit(entry);
+                  setSelectedCommitHashes([entry.hash]);
+                  setCommitSelectionAnchorHash(entry.hash);
+                  setSelectedFile(null);
+                }}
+                renderTooltip={renderTooltip}
+              />
+            )}
+            {viewMode === 'syncSettings' && workspaceInfo && 'wikiFolderLocation' in workspaceInfo && (
+              <GitLogSyncSettings workspace={workspaceInfo as unknown as import('@services/workspaces/interface').IWikiWorkspace} />
+            )}
           </TabContent>
         </GitLogWrapper>
         <DetailsWrapper>
-          {workspaceInfo
+          {viewMode === 'syncSettings'
             ? (
-              <DetailsPanelWrapper>
-                <CommitDetailsPanel
-                  commit={selectedCommit ?? null}
-                  selectedCommits={selectedCommits}
-                  workspaceID={workspaceInfo.id}
-                  showSnackbar={showSnackbar}
-                  onFileSelect={handleFileSelect}
-                  selectedFile={selectedFile}
-                  selectedFiles={selectedFiles}
-                  onCommitSuccess={handleCommitSuccess}
-                  onRevertSuccess={handleRevertSuccess}
-                  onUndoSuccess={handleUndoSuccess}
-                  isLatestCommit={selectedCommit?.hash === entries.find((entry) => entry.hash !== '')?.hash}
-                />
+              <DetailsPanelWrapper sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', p: 2 }}>
+                <Typography variant='body2' color='textSecondary'>
+                  {t('GitLog.SyncSettingsDescription')}
+                </Typography>
               </DetailsPanelWrapper>
             )
-            : (
-              <DetailsPanelWrapper
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  height: '100%',
-                }}
-              >
-                <CircularProgress />
-              </DetailsPanelWrapper>
-            )}
+            : workspaceInfo
+              ? (
+                <DetailsPanelWrapper>
+                  <CommitDetailsPanel
+                    commit={selectedCommit ?? null}
+                    selectedCommits={selectedCommits}
+                    workspaceID={workspaceInfo.id}
+                    storageService={'storageService' in workspaceInfo ? workspaceInfo.storageService : SupportedStorageServices.local}
+                    showSnackbar={showSnackbar}
+                    onFileSelect={handleFileSelect}
+                    selectedFile={selectedFile}
+                    selectedFiles={selectedFiles}
+                    onCommitSuccess={handleCommitSuccess}
+                    onRevertSuccess={handleRevertSuccess}
+                    onUndoSuccess={handleUndoSuccess}
+                    isLatestCommit={selectedCommit?.hash === entries.find((entry) => entry.hash !== '')?.hash}
+                  />
+                </DetailsPanelWrapper>
+              )
+              : (
+                <DetailsPanelWrapper
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                  }}
+                >
+                  <CircularProgress />
+                </DetailsPanelWrapper>
+              )}
         </DetailsWrapper>
 
         <DiffPanelWrapper>
-          {workspaceInfo
+          {viewMode === 'syncSettings'
             ? (
-              <FileDiffPanel
-                commitHash={selectedCommit?.hash || ''}
-                filePath={selectedFile}
-                selectedFiles={selectedFiles}
-                workspaceID={workspaceInfo.id}
-                onDiscardSuccess={handleFileActionSuccess}
-                showSnackbar={showSnackbar}
-              />
-            )
-            : (
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  height: '100%',
-                  width: '100%',
-                }}
-              >
-                <CircularProgress />
+              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', width: '100%' }}>
+                <Typography variant='body2' color='textSecondary'>
+                  {t('GitLog.SyncSettingsDescription')}
+                </Typography>
               </Box>
-            )}
+            )
+            : workspaceInfo
+              ? (
+                <FileDiffPanel
+                  commitHash={selectedCommit?.hash || ''}
+                  filePath={selectedFile}
+                  selectedFiles={selectedFiles}
+                  workspaceID={workspaceInfo.id}
+                  onDiscardSuccess={handleFileActionSuccess}
+                  showSnackbar={showSnackbar}
+                />
+              )
+              : (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    width: '100%',
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              )}
         </DiffPanelWrapper>
       </ContentWrapper>
 

--- a/src/windows/GitLog/useGitHistoryLogic.ts
+++ b/src/windows/GitLog/useGitHistoryLogic.ts
@@ -16,8 +16,8 @@ interface IUseGitHistoryStateReturn {
   setSelectedFiles: Dispatch<SetStateAction<string[]>>;
   fileSelectionAnchor: string | null;
   setFileSelectionAnchor: Dispatch<SetStateAction<string | null>>;
-  viewMode: 'current' | 'all';
-  setViewMode: Dispatch<SetStateAction<'current' | 'all'>>;
+  viewMode: 'current' | 'all' | 'syncSettings';
+  setViewMode: Dispatch<SetStateAction<'current' | 'all' | 'syncSettings'>>;
   shouldSelectFirst: boolean;
   setShouldSelectFirst: Dispatch<SetStateAction<boolean>>;
   currentSearchParameters: ISearchParameters;
@@ -32,7 +32,7 @@ export function useGitHistoryState(): IUseGitHistoryStateReturn {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
   const [selectedFiles, setSelectedFiles] = useState<string[]>([]);
   const [fileSelectionAnchor, setFileSelectionAnchor] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'current' | 'all'>('current');
+  const [viewMode, setViewMode] = useState<'current' | 'all' | 'syncSettings'>('current');
   const [shouldSelectFirst, setShouldSelectFirst] = useState(false);
   const [currentSearchParameters, setCurrentSearchParameters] = useState<ISearchParameters>({
     mode: 'none',

--- a/src/windows/GitLog/useGitLogData.ts
+++ b/src/windows/GitLog/useGitLogData.ts
@@ -1,5 +1,5 @@
-import type { IWorkspace } from '@services/workspaces/interface';
 import { SupportedStorageServices } from '@services/types';
+import type { IWorkspace } from '@services/workspaces/interface';
 import useObservable from 'beautiful-react-hooks/useObservable';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { filter } from 'rxjs/operators';

--- a/src/windows/GitLog/useGitLogData.ts
+++ b/src/windows/GitLog/useGitLogData.ts
@@ -1,4 +1,5 @@
 import type { IWorkspace } from '@services/workspaces/interface';
+import { SupportedStorageServices } from '@services/types';
 import useObservable from 'beautiful-react-hooks/useObservable';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { filter } from 'rxjs/operators';
@@ -180,11 +181,15 @@ export function useGitLogData(workspaceID: string): IGitLogData {
         void window.service.native.log('debug', '[DEBUG] getGitLog completed', { entryCount: result.entries.length });
 
         // Get unpushed commit hashes in parallel with loading files
-        const unpushedHashesPromise = window.service.git.callGitOp(
-          'getUnpushedCommitHashes',
-          workspaceInfo.wikiFolderLocation,
-          workspaceInfo.gitUrl,
-        );
+        // For local workspaces, skip this — users should convert to cloud workspace if they want remote sync.
+        const isLocalWorkspace = workspaceInfo.storageService === SupportedStorageServices.local;
+        const unpushedHashesPromise = isLocalWorkspace
+          ? Promise.resolve(new Set<string>())
+          : window.service.git.callGitOp(
+            'getUnpushedCommitHashes',
+            workspaceInfo.wikiFolderLocation,
+            workspaceInfo.gitUrl,
+          );
 
         // Load files for each commit
         const entriesWithFiles = await Promise.all(


### PR DESCRIPTION
## Summary

A batch of miscellaneous fixes addressing several issues:

### 1. feat: add copy image to clipboard in image context menu
- Added "Copy Image to Clipboard" option to the image right-click context menu in BrowserView
- Uses `copyImage()` i18n string, validates `response.ok` and `image.isEmpty()`

### 2. fix: hibernate/wake up sub-workspaces UI state together with main workspace
- Sub-workspaces don't have their own wiki service or BrowserView, so only the hibernated UI flag needs to be updated
- This ensures their sidebar icons turn gray/restored in sync with the main workspace

### 3. fix: replace dynamic import() with static imports to fix Node.js 22 ESM error
- In Electron 41 (Node.js 22), dynamic import() with path aliases (@/, @services/) fails at runtime in bundled code with 'TypeError: A dynamic import callback was not specified'
- This crashed the app on first install when showDisclosureIfNeeded() tried to dynamically import environment constants
- Converted all dynamic imports to static top-level imports across multiple files

### 4. fix: preserve .tid file format in FileSystemWatcher.loadTiddler() (Closes #669)
- **Root cause**: `loadTiddler()` was using the tiddler's content type (e.g. 'text/markdown') as the file format type in `boot.files[title].type`. TiddlyWiki's `saveTiddlerToFile()` only uses .tid format when `fileInfo.type === 'application/x-tiddler'`, so any other type caused subsequent saves to use JSON format.
- **Fix**:
  - Added `cachedFileDescriptor` to `IFileChange` to store file-level metadata
  - Use `fileDescriptor.type` (file format) not `tiddler.type` (content type) when updating boot.files
  - Added `inferFileTypeFromExtension()` fallback for robustness
  - Detect unexpected .tid → .json format changes with warning log
  - Normalize line endings in content identity check for echo prevention
- **Tests**: Added 7 new unit tests covering the type preservation logic
- **E2E**: All filesystem watcher E2E tests pass (filesystemPlugin, smoke watcher re-index, crossWindowSync)

## Test Results
- Unit tests: 87/87 passed
- E2E tests: 4 scenarios, 99 steps, all passed
