### PR TITLE
feat: expose getTiddlerRoutingInfo for sub-wiki routing UI

### DIFF
--- a/docs/features/SubWiki.md
+++ b/docs/features/SubWiki.md
@@ -14,6 +14,8 @@ These configs are editable by user using EditWorkspace's SubWiki section.
 
 Tiddlers not matched to any sub-wiki are saved to the main workspace.
 
+UI plugins can call `window.service.wiki.getTiddlerRoutingInfo(title)` to read the same decision (winning workspace + tag chain) without reimplementing priority rules. `featureAvailable` is true only when the main wiki has at least one sub-wiki with routing settings enabled.
+
 ## File Watching
 
 WatchFileSystemAdaptor reads the external attachment folder name from `$:/config/ExternalAttachments/WikiFolderToMove` (default `files`) and excludes this folder from watching. This prevents external attachments from being repeatedly created as tiddlers.

--- a/src/services/wiki/index.ts
+++ b/src/services/wiki/index.ts
@@ -32,6 +32,7 @@ import { Observable } from 'rxjs';
 import { AlreadyExistError, CopyWikiTemplateError, HTMLCanNotLoadError, WikiRuntimeError } from './error';
 import type { IWikiService, IWorkerInfo } from './interface';
 import { WikiControlActions } from './interface';
+import type { ITiddlerRoutingInfo } from './plugin/watchFileSystemAdaptor/tiddlerRoutingInfo';
 import type { IStartNodeJSWikiConfigs, WikiWorker } from './wikiWorker';
 import type { IpcServerRouteMethods, IpcServerRouteNames, ITidGiChangedTiddlers } from './wikiWorker/ipcServerRoutes';
 
@@ -1005,6 +1006,15 @@ export class Wiki implements IWikiService {
         return tiddlerFileMetadata.filepath;
       }
     }
+  }
+
+  public async getTiddlerRoutingInfo(title: string, workspaceID?: string): Promise<ITiddlerRoutingInfo> {
+    const workspaceService = container.get<IWorkspaceService>(serviceIdentifier.Workspace);
+    const wikiWorker = this.getWorker(workspaceID ?? (await workspaceService.getActiveWorkspace())?.id ?? '');
+    if (wikiWorker !== undefined) {
+      return await wikiWorker.getTiddlerRoutingInfo(title);
+    }
+    return { featureAvailable: false };
   }
 
   public async getWikiErrorLogs(_workspaceID: string, wikiName: string): Promise<{ content: string; filePath: string }> {

--- a/src/services/wiki/interface.ts
+++ b/src/services/wiki/interface.ts
@@ -3,11 +3,11 @@ import type { IGitUserInfos } from '@services/git/interface';
 import type { IWorkspace } from '@services/workspaces/interface';
 import { ProxyPropertyType } from 'electron-ipc-cat/common';
 import type { Observable } from 'rxjs';
+import type { ITiddlerRoutingInfo } from './plugin/watchFileSystemAdaptor/tiddlerRoutingInfo';
 import type { IWorkerWikiOperations } from './wikiOperations/executor/wikiOperationInServer';
 import type { ISendWikiOperationsToBrowser } from './wikiOperations/sender/sendWikiOperationsToBrowser';
 import type { WikiWorker } from './wikiWorker';
 import type { IpcServerRouteMethods, IpcServerRouteNames, ITidGiChangedTiddlers, IWikiServerRouteResponse } from './wikiWorker/ipcServerRoutes';
-import type { ITiddlerRoutingInfo } from './plugin/watchFileSystemAdaptor/tiddlerRoutingInfo';
 
 /**
  * Handle wiki worker startup and restart

--- a/src/services/wiki/interface.ts
+++ b/src/services/wiki/interface.ts
@@ -7,6 +7,7 @@ import type { IWorkerWikiOperations } from './wikiOperations/executor/wikiOperat
 import type { ISendWikiOperationsToBrowser } from './wikiOperations/sender/sendWikiOperationsToBrowser';
 import type { WikiWorker } from './wikiWorker';
 import type { IpcServerRouteMethods, IpcServerRouteNames, ITidGiChangedTiddlers, IWikiServerRouteResponse } from './wikiWorker/ipcServerRoutes';
+import type { ITiddlerRoutingInfo } from './plugin/watchFileSystemAdaptor/tiddlerRoutingInfo';
 
 /**
  * Handle wiki worker startup and restart
@@ -44,6 +45,11 @@ export interface IWikiService {
    * @param title tiddler title to open
    */
   getTiddlerFilePath(title: string, workspaceID?: string): Promise<string | undefined>;
+  /**
+   * Explain which workspace a tiddler would be routed to (same rules as FileSystemAdaptor save routing).
+   * `featureAvailable` is true only when the main wiki has at least one sub-wiki with routing settings enabled.
+   */
+  getTiddlerRoutingInfo(title: string, workspaceID?: string): Promise<ITiddlerRoutingInfo>;
   getWikiChangeObserver$(workspaceID: string): Observable<ITidGiChangedTiddlers>;
   getWikiErrorLogs(workspaceID: string, wikiName: string): Promise<{ content: string; filePath: string }>;
   /**
@@ -118,6 +124,7 @@ export const WikiServiceIPCDescriptor = {
     getWikiErrorLogs: ProxyPropertyType.Function,
     getWorkersInfo: ProxyPropertyType.Function,
     getTiddlerFilePath: ProxyPropertyType.Function,
+    getTiddlerRoutingInfo: ProxyPropertyType.Function,
     packetHTMLFromWikiFolder: ProxyPropertyType.Function,
     removeWiki: ProxyPropertyType.Function,
     restartWiki: ProxyPropertyType.Function,

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemAdaptor.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/FileSystemAdaptor.ts
@@ -9,6 +9,7 @@ import type { IFileInfo } from 'tiddlywiki';
 import type { Tiddler, Wiki } from 'tiddlywiki';
 import { moveExternalAttachmentIfNeeded } from './externalAttachmentUtilities';
 import type { ExtendedUtilities } from './routingUtilities.type';
+import type { ITiddlerRoutingInfo } from './tiddlerRoutingInfo';
 import { isFileLockError } from './utilities';
 
 /**
@@ -97,6 +98,25 @@ export class FileSystemAdaptor {
     } catch (error) {
       this.logger.alert('filesystem: Failed to update sub-wikis cache:', error);
     }
+  }
+
+  /**
+   * Explain where a tiddler would be routed, using the same rules as save routing.
+   * Intended for UI plugins (e.g. routing-chain indicator) so they do not reimplement priority.
+   */
+  public async getTiddlerRoutingInfo(tiddlerTitle: string): Promise<ITiddlerRoutingInfo> {
+    await this.updateSubWikisCache();
+    // Use $tw.wiki (same as getTiddlerFileInfo / save routing) so tag index and filters stay consistent.
+    const tiddler = $tw.wiki.getTiddler?.(tiddlerTitle) ?? this.wiki.getTiddler?.(tiddlerTitle);
+    const tiddlerTags = tiddler?.fields.tags ?? [];
+    return ($tw.utils as unknown as ExtendedUtilities).buildTiddlerRoutingInfo(
+      tiddlerTitle,
+      tiddlerTags,
+      this.wikisWithRouting,
+      this.workspaceID,
+      $tw.wiki,
+      $tw.rootWidget,
+    );
   }
 
   isReady(): boolean {

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemAdaptor.routing.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/FileSystemAdaptor.routing.test.ts
@@ -8,7 +8,7 @@ import { FileSystemAdaptor } from '../FileSystemAdaptor';
 // path.resolve makes paths absolute; on Windows '/test/wiki/tiddlers' becomes 'C:\test\wiki\tiddlers'
 const RESOLVED_TIDDLERS_PATH = path.resolve('/test/wiki/tiddlers');
 // @ts-expect-error TS2459: Module declares 'matchTiddlerToWorkspace' locally, but it is not exported. Ignore: TiddlyWiki uses exports.xxx style.
-import { isWikiWorkspaceWithRouting, matchTiddlerToWorkspace } from '../routingUtilities';
+import { buildTiddlerRoutingInfo, isWikiWorkspaceWithRouting, matchTiddlerToWorkspace } from '../routingUtilities';
 
 // Mock the workspace service
 vi.mock('@services/wiki/wikiWorker/services', () => ({
@@ -36,6 +36,7 @@ const mockUtils = {
   getFileExtensionInfo: vi.fn(() => ({ type: 'application/x-tiddler' })),
   matchTiddlerToWorkspace,
   isWikiWorkspaceWithRouting,
+  buildTiddlerRoutingInfo,
 };
 
 // Setup TiddlyWiki global
@@ -50,6 +51,8 @@ global.$tw = {
   wiki: {
     filterTiddlers: vi.fn(() => []),
     makeTiddlerIterator: vi.fn((titles: string[]) => titles),
+    getTiddler: vi.fn(() => undefined),
+    getTiddlersWithTag: vi.fn(() => []),
   },
   rootWidget: {
     makeFakeWidgetWithVariables: vi.fn(() => ({})),
@@ -1019,6 +1022,92 @@ describe('FileSystemAdaptor - Routing Logic', () => {
           directory: '/test/wiki/subwiki/first',
         }),
       );
+    });
+  });
+
+  describe('getTiddlerRoutingInfo', () => {
+    beforeEach(async () => {
+      vi.mocked(workspace.get).mockResolvedValue(
+        {
+          id: 'test-workspace',
+          name: 'Test Workspace',
+          wikiFolderLocation: '/test/wiki',
+        } as Parameters<typeof workspace.get>[0] extends Promise<infer T> ? T : never,
+      );
+
+      mockWiki = {
+        getTiddlerText: vi.fn((title) => {
+          if (title === '$:/info/tidgi/workspaceID') return 'test-workspace';
+          return '';
+        }),
+        getTiddler: vi.fn((title: string) => {
+          if (title === 'ChildTiddler') {
+            return { fields: { title: 'ChildTiddler', tags: ['ParentTag'] } };
+          }
+          return undefined;
+        }),
+        tiddlerExists: vi.fn(() => false),
+        addTiddler: vi.fn(),
+      } as unknown as Wiki;
+    });
+
+    it('reports featureAvailable=false without routed sub-wiki', async () => {
+      vi.mocked(workspace.getWorkspacesAsList).mockResolvedValue([]);
+
+      adaptor = new FileSystemAdaptor({
+        wiki: mockWiki,
+        // @ts-expect-error - TiddlyWiki global
+        boot: global.$tw.boot,
+      });
+
+      const info = await adaptor.getTiddlerRoutingInfo('ChildTiddler');
+      expect(info).toEqual({ featureAvailable: false });
+    });
+
+    it('returns match payload for tag-tree routing', async () => {
+      const subWiki = {
+        id: 'sub-wiki-tagtree',
+        name: 'Sub Wiki TagTree',
+        isSubWiki: true,
+        mainWikiID: 'test-workspace',
+        tagNames: ['RootTag'],
+        includeTagTree: true,
+        wikiFolderLocation: '/test/wiki/subwiki/tagtree',
+      };
+
+      vi.mocked(workspace.getWorkspacesAsList).mockResolvedValue([subWiki] as IWikiWorkspace[]);
+      // @ts-expect-error - TiddlyWiki global
+      global.$tw.wiki.getTiddler = vi.fn((title: string) => {
+        if (title === 'ChildTiddler') {
+          return { fields: { title: 'ChildTiddler', tags: ['ParentTag'] } };
+        }
+        return undefined;
+      });
+      // @ts-expect-error - TiddlyWiki global
+      global.$tw.wiki.filterTiddlers = vi.fn(() => ['ChildTiddler']);
+      // @ts-expect-error - TiddlyWiki global
+      global.$tw.wiki.getTiddlersWithTag = vi.fn((tag: string) => {
+        if (tag === 'RootTag') return ['ParentTag'];
+        if (tag === 'ParentTag') return ['ChildTiddler'];
+        return [];
+      });
+
+      adaptor = new FileSystemAdaptor({
+        wiki: mockWiki,
+        // @ts-expect-error - TiddlyWiki global
+        boot: global.$tw.boot,
+      });
+
+      const info = await adaptor.getTiddlerRoutingInfo('ChildTiddler');
+      expect(info.featureAvailable).toBe(true);
+      expect(info.match).toEqual({
+        workspaceId: 'sub-wiki-tagtree',
+        workspaceName: 'Sub Wiki TagTree',
+        isSubWiki: true,
+        kind: 'tag-tree',
+        chain: 'RootTag → ParentTag → ChildTiddler',
+        rootTag: 'RootTag',
+      });
     });
   });
 });

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/routingUtilities.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/routingUtilities.test.ts
@@ -15,16 +15,16 @@ const makeWiki = (tagMap: Record<string, string[]> = {}) => ({
 describe('routingUtilities', () => {
   describe('hasRoutingConfig / hasActiveSubWikiRouting', () => {
     it('detects tagNames and filter routing configs', () => {
-      expect(hasRoutingConfig({ tagNames: ['A'] } as unknown as IWikiWorkspace)).toBe(true);
+      expect(hasRoutingConfig({ tagNames: ['A'] })).toBe(true);
       expect(hasRoutingConfig({
         tagNames: [],
         fileSystemPathFilterEnable: true,
         fileSystemPathFilter: '[tag[A]]',
-      } as unknown as IWikiWorkspace)).toBe(true);
+      })).toBe(true);
       expect(hasRoutingConfig({
         tagNames: [],
         fileSystemPathFilterEnable: false,
-      } as unknown as IWikiWorkspace)).toBe(false);
+      })).toBe(false);
     });
 
     it('requires a sub-wiki with routing for feature availability', () => {
@@ -55,7 +55,7 @@ describe('routingUtilities', () => {
           tagNames: [],
           fileSystemPathFilterEnable: false,
           fileSystemPathFilter: null,
-        } as unknown as IWikiWorkspace,
+        },
       ], mainId)).toBe(false);
     });
   });
@@ -152,7 +152,7 @@ describe('routingUtilities', () => {
     });
 
     it('explains direct tag match', () => {
-      wiki.filterTiddlers = vi.fn(() => []) as typeof wiki.filterTiddlers;
+      wiki.filterTiddlers = vi.fn(() => []);
 
       const explanation = explainTiddlerRouting('Note', ['PrivateRoot'], [main, sub], wiki, rootWidget);
       expect(explanation?.kind).toBe('direct-tag');
@@ -185,7 +185,7 @@ describe('routingUtilities', () => {
         fileSystemPathFilter: '[prefix[$:/Deck/]]',
       } as unknown as IWikiWorkspace;
 
-      wiki.filterTiddlers = vi.fn((filter: string) => filter.includes('prefix') ? ['$:/Deck/A'] : []) as typeof wiki.filterTiddlers;
+      wiki.filterTiddlers = vi.fn((filter: string) => filter.includes('prefix') ? ['$:/Deck/A'] : []);
 
       const explanation = explainTiddlerRouting('$:/Deck/A', [], [main, filterWorkspace], wiki, rootWidget);
       expect(explanation?.kind).toBe('filter');

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/routingUtilities.test.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/__tests__/routingUtilities.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for routingUtilities helpers used by FileSystemAdaptor and getTiddlerRoutingInfo.
+ */
+import type { IWikiWorkspace } from '@services/workspaces/interface';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error TS2459: TiddlyWiki uses exports.xxx style.
+import { buildTiddlerRoutingInfo, explainTiddlerRouting, findTagTreePath, hasActiveSubWikiRouting, hasRoutingConfig, matchTiddlerToWorkspace } from '../routingUtilities';
+
+const makeWiki = (tagMap: Record<string, string[]> = {}) => ({
+  getTiddlersWithTag: vi.fn((tag: string) => tagMap[tag] ?? []),
+  filterTiddlers: vi.fn(() => []),
+  makeTiddlerIterator: vi.fn((titles: string[]) => titles),
+});
+
+describe('routingUtilities', () => {
+  describe('hasRoutingConfig / hasActiveSubWikiRouting', () => {
+    it('detects tagNames and filter routing configs', () => {
+      expect(hasRoutingConfig({ tagNames: ['A'] } as unknown as IWikiWorkspace)).toBe(true);
+      expect(hasRoutingConfig({
+        tagNames: [],
+        fileSystemPathFilterEnable: true,
+        fileSystemPathFilter: '[tag[A]]',
+      } as unknown as IWikiWorkspace)).toBe(true);
+      expect(hasRoutingConfig({
+        tagNames: [],
+        fileSystemPathFilterEnable: false,
+      } as unknown as IWikiWorkspace)).toBe(false);
+    });
+
+    it('requires a sub-wiki with routing for feature availability', () => {
+      const mainId = 'main';
+      const workspaces = [
+        {
+          id: mainId,
+          name: 'main',
+          isSubWiki: false,
+          tagNames: ['Public'],
+          includeTagTree: true,
+        },
+        {
+          id: 'sub',
+          name: 'private',
+          isSubWiki: true,
+          mainWikiID: mainId,
+          tagNames: ['Private'],
+          includeTagTree: true,
+        },
+      ] as unknown as IWikiWorkspace[];
+
+      expect(hasActiveSubWikiRouting(workspaces, mainId)).toBe(true);
+      expect(hasActiveSubWikiRouting([workspaces[0]], mainId)).toBe(false);
+      expect(hasActiveSubWikiRouting([
+        {
+          ...workspaces[1],
+          tagNames: [],
+          fileSystemPathFilterEnable: false,
+          fileSystemPathFilter: null,
+        } as unknown as IWikiWorkspace,
+      ], mainId)).toBe(false);
+    });
+  });
+
+  describe('findTagTreePath', () => {
+    it('returns path from root to descendant', () => {
+      const wiki = makeWiki({
+        Root: ['Mid'],
+        Mid: ['Leaf'],
+      }) as unknown as typeof $tw.wiki;
+
+      expect(findTagTreePath('Root', 'Leaf', wiki)).toEqual(['Root', 'Mid', 'Leaf']);
+      expect(findTagTreePath('Root', 'Missing', wiki)).toBeUndefined();
+      expect(findTagTreePath('Root', 'Root', wiki)).toEqual(['Root']);
+    });
+
+    it('returns undefined when getTiddlersWithTag is unavailable', () => {
+      const wiki = { filterTiddlers: vi.fn() } as unknown as typeof $tw.wiki;
+      expect(findTagTreePath('Root', 'Leaf', wiki)).toBeUndefined();
+    });
+  });
+
+  describe('explainTiddlerRouting / matchTiddlerToWorkspace / buildTiddlerRoutingInfo', () => {
+    const main = {
+      id: 'main',
+      name: 'wiki',
+      isSubWiki: false,
+      mainWikiID: null,
+      order: 0,
+      tagNames: ['PublicRoot'],
+      includeTagTree: true,
+      fileSystemPathFilterEnable: false,
+      fileSystemPathFilter: null,
+      wikiFolderLocation: '/wiki',
+    } as unknown as IWikiWorkspace;
+
+    const sub = {
+      id: 'sub',
+      name: 'private-wiki',
+      isSubWiki: true,
+      mainWikiID: 'main',
+      order: 1,
+      tagNames: ['PrivateRoot'],
+      includeTagTree: true,
+      fileSystemPathFilterEnable: false,
+      fileSystemPathFilter: null,
+      wikiFolderLocation: '/private',
+    } as unknown as IWikiWorkspace;
+
+    let wiki: typeof $tw.wiki;
+    let rootWidget: typeof $tw.rootWidget;
+
+    beforeEach(() => {
+      wiki = {
+        getTiddlersWithTag: vi.fn((tag: string) => {
+          if (tag === 'PublicRoot') return ['SharedMid'];
+          if (tag === 'PrivateRoot') return ['SharedMid'];
+          if (tag === 'SharedMid') return ['Child'];
+          return [];
+        }),
+        filterTiddlers: vi.fn((_filter: string, widget: { tagName?: string }) => {
+          const tagName = widget.tagName;
+          if (tagName === 'PublicRoot' || tagName === 'PrivateRoot') {
+            return ['Child'];
+          }
+          return [];
+        }),
+        makeTiddlerIterator: vi.fn((titles: string[]) => titles),
+      } as unknown as typeof $tw.wiki;
+
+      rootWidget = {
+        makeFakeWidgetWithVariables: vi.fn((vars: { tagName: string }) => vars),
+      } as unknown as typeof $tw.rootWidget;
+    });
+
+    it('explains tag-tree match with readable chain and respects workspace order', () => {
+      const explanation = explainTiddlerRouting('Child', ['SharedMid'], [main, sub], wiki, rootWidget);
+      expect(explanation?.workspace.id).toBe('main');
+      expect(explanation?.kind).toBe('tag-tree');
+      expect(explanation?.chain).toBe('PublicRoot → SharedMid → Child');
+      expect(explanation?.rootTag).toBe('PublicRoot');
+
+      expect(matchTiddlerToWorkspace('Child', ['SharedMid'], [main, sub], wiki, rootWidget)?.id).toBe('main');
+    });
+
+    it('prefers later workspace when earlier does not match', () => {
+      wiki.filterTiddlers = vi.fn((_filter: string, widget: { tagName?: string }) => {
+        return widget.tagName === 'PrivateRoot' ? ['Child'] : [];
+      }) as typeof wiki.filterTiddlers;
+
+      const explanation = explainTiddlerRouting('Child', ['SharedMid'], [main, sub], wiki, rootWidget);
+      expect(explanation?.workspace.id).toBe('sub');
+      expect(explanation?.chain).toBe('PrivateRoot → SharedMid → Child');
+    });
+
+    it('explains direct tag match', () => {
+      wiki.filterTiddlers = vi.fn(() => []) as typeof wiki.filterTiddlers;
+
+      const explanation = explainTiddlerRouting('Note', ['PrivateRoot'], [main, sub], wiki, rootWidget);
+      expect(explanation?.kind).toBe('direct-tag');
+      expect(explanation?.workspace.id).toBe('sub');
+      expect(explanation?.chain).toBe('PrivateRoot → Note');
+    });
+
+    it('buildTiddlerRoutingInfo sets featureAvailable only with routed sub-wiki', () => {
+      const withoutSub = buildTiddlerRoutingInfo('Child', ['SharedMid'], [main], 'main', wiki, rootWidget);
+      expect(withoutSub.featureAvailable).toBe(false);
+      expect(withoutSub.match).toBeUndefined();
+
+      const withSub = buildTiddlerRoutingInfo('Child', ['SharedMid'], [main, sub], 'main', wiki, rootWidget);
+      expect(withSub.featureAvailable).toBe(true);
+      expect(withSub.match).toEqual(expect.objectContaining({
+        workspaceId: 'main',
+        workspaceName: 'wiki',
+        isSubWiki: false,
+        kind: 'tag-tree',
+        chain: 'PublicRoot → SharedMid → Child',
+      }));
+    });
+
+    it('explains filter matches', () => {
+      const filterWorkspace = {
+        ...sub,
+        tagNames: [],
+        includeTagTree: false,
+        fileSystemPathFilterEnable: true,
+        fileSystemPathFilter: '[prefix[$:/Deck/]]',
+      } as unknown as IWikiWorkspace;
+
+      wiki.filterTiddlers = vi.fn((filter: string) => filter.includes('prefix') ? ['$:/Deck/A'] : []) as typeof wiki.filterTiddlers;
+
+      const explanation = explainTiddlerRouting('$:/Deck/A', [], [main, filterWorkspace], wiki, rootWidget);
+      expect(explanation?.kind).toBe('filter');
+      expect(explanation?.chain).toBe('[prefix[$:/Deck/]]');
+      expect(explanation?.workspace.id).toBe('sub');
+    });
+  });
+});

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
@@ -1,22 +1,12 @@
 import type { IWikiWorkspace, IWorkspace } from '@services/workspaces/interface';
 import { workspaceSorter } from '@services/workspaces/utilities';
-import type { ITiddlerRoutingInfo, TiddlerRoutingMatchKind } from './tiddlerRoutingInfo';
+import type { ITiddlerRoutingExplanation } from './routingUtilities.type';
+import type { ITiddlerRoutingInfo } from './tiddlerRoutingInfo';
 
 /**
  * Sub-wiki routing utilities for matching tiddlers/files to workspaces.
  * These utilities are exposed as $tw.utils functions for use in plugins / IPC APIs.
  */
-
-/**
- * Detailed explanation of why a tiddler is routed to a workspace.
- * Kept in sync with FileSystemAdaptor save routing so UI plugins do not reimplement priority rules.
- */
-interface ITiddlerRoutingExplanation {
-  workspace: IWikiWorkspace;
-  kind: TiddlerRoutingMatchKind;
-  chain: string;
-  rootTag?: string;
-}
 
 /**
  * Check if a workspace has routing configuration (tagNames or fileSystemPathFilter).
@@ -118,9 +108,10 @@ function findTagTreePath(
 
   const queue: string[][] = [[rootTag]];
   const seen = new Set<string>([rootTag]);
+  let head = 0;
 
-  while (queue.length > 0) {
-    const currentPath = queue.shift()!;
+  while (head < queue.length) {
+    const currentPath = queue[head++];
     if (currentPath.length > maxDepth) {
       continue;
     }

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
@@ -290,7 +290,7 @@ function buildTiddlerRoutingInfo(
     match: {
       workspaceId: explanation.workspace.id,
       workspaceName: explanation.workspace.name,
-      isSubWiki: Boolean(explanation.workspace.isSubWiki),
+      isSubWiki: explanation.workspace.isSubWiki,
       kind: explanation.kind,
       chain: explanation.chain,
       rootTag: explanation.rootTag,

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.ts
@@ -1,10 +1,22 @@
 import type { IWikiWorkspace, IWorkspace } from '@services/workspaces/interface';
 import { workspaceSorter } from '@services/workspaces/utilities';
+import type { ITiddlerRoutingInfo, TiddlerRoutingMatchKind } from './tiddlerRoutingInfo';
 
 /**
  * Sub-wiki routing utilities for matching tiddlers/files to workspaces.
- * These utilities are exposed as $tw.utils functions for use in plugins.
+ * These utilities are exposed as $tw.utils functions for use in plugins / IPC APIs.
  */
+
+/**
+ * Detailed explanation of why a tiddler is routed to a workspace.
+ * Kept in sync with FileSystemAdaptor save routing so UI plugins do not reimplement priority rules.
+ */
+interface ITiddlerRoutingExplanation {
+  workspace: IWikiWorkspace;
+  kind: TiddlerRoutingMatchKind;
+  chain: string;
+  rootTag?: string;
+}
 
 /**
  * Check if a workspace has routing configuration (tagNames or fileSystemPathFilter).
@@ -19,6 +31,20 @@ function hasRoutingConfig(workspaceItem: IWorkspace): boolean {
 }
 
 /**
+ * True when there is at least one sub-wiki (of this main wiki) that has routing config enabled.
+ */
+function hasActiveSubWikiRouting(
+  workspacesWithRouting: IWikiWorkspace[],
+  mainWorkspaceId: string,
+): boolean {
+  return workspacesWithRouting.some((workspaceItem) =>
+    workspaceItem.isSubWiki &&
+    workspaceItem.mainWikiID === mainWorkspaceId &&
+    hasRoutingConfig(workspaceItem)
+  );
+}
+
+/**
  * Check if a workspace is a wiki workspace with routing configuration.
  * This filters to wiki workspaces that are either the main workspace or sub-wikis of it.
  */
@@ -26,20 +52,15 @@ function isWikiWorkspaceWithRouting(
   workspaceItem: IWorkspace,
   mainWorkspaceId: string,
 ): workspaceItem is IWikiWorkspace {
-  // Must have wiki folder location
   if (!('wikiFolderLocation' in workspaceItem) || !workspaceItem.wikiFolderLocation) {
     return false;
   }
 
-  // Must have routing config
   if (!hasRoutingConfig(workspaceItem)) {
     return false;
   }
 
-  // Include if it's the main workspace
   const isMain = workspaceItem.id === mainWorkspaceId;
-
-  // Include if it's a sub-wiki of the current main workspace
   const isSubWiki = 'isSubWiki' in workspaceItem &&
     workspaceItem.isSubWiki &&
     'mainWikiID' in workspaceItem &&
@@ -50,23 +71,73 @@ function isWikiWorkspaceWithRouting(
 
 /**
  * Check if a tiddler matches a workspace's direct tag routing.
- * Returns true if:
- * - Any of the tiddler's tags match any of the workspace's tagNames
- * - The tiddler's title IS one of the tagNames (it's a "tag tiddler")
  */
 function matchesDirectTag(
   tiddlerTitle: string,
   tiddlerTags: string[],
   workspaceTagNames: string[],
 ): boolean {
+  return getDirectTagMatch(tiddlerTitle, tiddlerTags, workspaceTagNames) !== undefined;
+}
+
+/**
+ * Return the workspace tagName that directly matches this tiddler, if any.
+ */
+function getDirectTagMatch(
+  tiddlerTitle: string,
+  tiddlerTags: string[],
+  workspaceTagNames: string[],
+): string | undefined {
   if (workspaceTagNames.length === 0) {
-    return false;
+    return undefined;
   }
 
-  const hasMatchingTag = workspaceTagNames.some(tagName => tiddlerTags.includes(tagName));
-  const isTitleATagName = workspaceTagNames.includes(tiddlerTitle);
+  if (workspaceTagNames.includes(tiddlerTitle)) {
+    return tiddlerTitle;
+  }
 
-  return hasMatchingTag || isTitleATagName;
+  return workspaceTagNames.find((tagName) => tiddlerTags.includes(tagName));
+}
+
+/**
+ * Find a downward tag-tree path from root to target using getTiddlersWithTag BFS.
+ */
+function findTagTreePath(
+  rootTag: string,
+  targetTitle: string,
+  wiki: typeof $tw.wiki,
+  maxDepth = 32,
+): string[] | undefined {
+  if (typeof wiki.getTiddlersWithTag !== 'function') {
+    return undefined;
+  }
+
+  if (rootTag === targetTitle) {
+    return [rootTag];
+  }
+
+  const queue: string[][] = [[rootTag]];
+  const seen = new Set<string>([rootTag]);
+
+  while (queue.length > 0) {
+    const currentPath = queue.shift()!;
+    if (currentPath.length > maxDepth) {
+      continue;
+    }
+    const last = currentPath[currentPath.length - 1];
+    const children = wiki.getTiddlersWithTag(last) ?? [];
+    for (const child of children) {
+      if (child === targetTitle) {
+        return [...currentPath, child];
+      }
+      if (!seen.has(child)) {
+        seen.add(child);
+        queue.push([...currentPath, child]);
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**
@@ -101,26 +172,87 @@ function matchesCustomFilter(
   filterExpression: string,
   wiki: typeof $tw.wiki,
 ): boolean {
-  const filters = filterExpression.split('\n').map(f => f.trim()).filter(f => f.length > 0);
+  return getMatchedCustomFilter(tiddlerTitle, filterExpression, wiki) !== undefined;
+}
+
+function getMatchedCustomFilter(
+  tiddlerTitle: string,
+  filterExpression: string,
+  wiki: typeof $tw.wiki,
+): string | undefined {
+  const filters = filterExpression.split('\n').map((f) => f.trim()).filter((f) => f.length > 0);
 
   for (const filter of filters) {
     const result = wiki.filterTiddlers(filter, undefined, wiki.makeTiddlerIterator([tiddlerTitle]));
     if (result.length > 0) {
-      return true;
+      return filter;
     }
   }
 
-  return false;
+  return undefined;
+}
+
+/**
+ * Explain why a tiddler is routed to a workspace (same priority rules as save routing).
+ * Workspaces must already be sorted by the product's routing priority.
+ */
+function explainTiddlerRouting(
+  tiddlerTitle: string,
+  tiddlerTags: string[],
+  workspacesWithRouting: IWikiWorkspace[],
+  wiki: typeof $tw.wiki,
+  rootWidget: typeof $tw.rootWidget,
+): ITiddlerRoutingExplanation | undefined {
+  for (const workspaceItem of workspacesWithRouting) {
+    const directRoot = getDirectTagMatch(tiddlerTitle, tiddlerTags, workspaceItem.tagNames);
+    if (directRoot !== undefined) {
+      const chain = directRoot === tiddlerTitle ? directRoot : `${directRoot} → ${tiddlerTitle}`;
+      return {
+        workspace: workspaceItem,
+        kind: 'direct-tag',
+        chain,
+        rootTag: directRoot,
+      };
+    }
+
+    if (workspaceItem.includeTagTree && workspaceItem.tagNames.length > 0) {
+      for (const rootTag of workspaceItem.tagNames) {
+        // Match with the same operator used by save routing.
+        const matched = wiki.filterTiddlers(
+          `[in-tagtree-of:inclusive<tagName>]`,
+          rootWidget.makeFakeWidgetWithVariables({ tagName: rootTag }),
+          wiki.makeTiddlerIterator([tiddlerTitle]),
+        );
+        if (matched.length > 0) {
+          const path = findTagTreePath(rootTag, tiddlerTitle, wiki) ?? [rootTag, tiddlerTitle];
+          return {
+            workspace: workspaceItem,
+            kind: 'tag-tree',
+            chain: path.join(' → '),
+            rootTag,
+          };
+        }
+      }
+    }
+
+    if (workspaceItem.fileSystemPathFilterEnable && workspaceItem.fileSystemPathFilter) {
+      const matchedFilter = getMatchedCustomFilter(tiddlerTitle, workspaceItem.fileSystemPathFilter, wiki);
+      if (matchedFilter !== undefined) {
+        return {
+          workspace: workspaceItem,
+          kind: 'filter',
+          chain: matchedFilter,
+        };
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**
  * Match a tiddler to a workspace based on routing rules.
  * Checks workspaces in order (priority) and returns the first match.
- *
- * For each workspace, checks in order (any match wins):
- * 1. Direct tag match (including if tiddler's title IS one of the tagNames)
- * 2. If includeTagTree is enabled, use in-tagtree-of filter for recursive tag matching
- * 3. If fileSystemPathFilterEnable is enabled, use custom filter expressions
  */
 function matchTiddlerToWorkspace(
   tiddlerTitle: string,
@@ -129,35 +261,54 @@ function matchTiddlerToWorkspace(
   wiki: typeof $tw.wiki,
   rootWidget: typeof $tw.rootWidget,
 ): IWikiWorkspace | undefined {
-  for (const workspace of workspacesWithRouting) {
-    // 1. Direct tag match
-    if (matchesDirectTag(tiddlerTitle, tiddlerTags, workspace.tagNames)) {
-      return workspace;
-    }
+  return explainTiddlerRouting(tiddlerTitle, tiddlerTags, workspacesWithRouting, wiki, rootWidget)?.workspace;
+}
 
-    // 2. Tag tree match (if enabled)
-    if (workspace.includeTagTree && workspace.tagNames.length > 0) {
-      if (matchesTagTree(tiddlerTitle, workspace.tagNames, wiki, rootWidget)) {
-        return workspace;
-      }
-    }
-
-    // 3. Custom filter match (if enabled)
-    if (workspace.fileSystemPathFilterEnable && workspace.fileSystemPathFilter) {
-      if (matchesCustomFilter(tiddlerTitle, workspace.fileSystemPathFilter, wiki)) {
-        return workspace;
-      }
-    }
+/**
+ * Build the IPC/UI payload for a tiddler's routing decision.
+ */
+function buildTiddlerRoutingInfo(
+  tiddlerTitle: string,
+  tiddlerTags: string[],
+  workspacesWithRouting: IWikiWorkspace[],
+  mainWorkspaceId: string,
+  wiki: typeof $tw.wiki,
+  rootWidget: typeof $tw.rootWidget,
+): ITiddlerRoutingInfo {
+  const featureAvailable = hasActiveSubWikiRouting(workspacesWithRouting, mainWorkspaceId);
+  if (!featureAvailable) {
+    return { featureAvailable: false };
   }
 
-  return undefined;
+  const explanation = explainTiddlerRouting(tiddlerTitle, tiddlerTags, workspacesWithRouting, wiki, rootWidget);
+  if (!explanation) {
+    return { featureAvailable: true };
+  }
+
+  return {
+    featureAvailable: true,
+    match: {
+      workspaceId: explanation.workspace.id,
+      workspaceName: explanation.workspace.name,
+      isSubWiki: Boolean(explanation.workspace.isSubWiki),
+      kind: explanation.kind,
+      chain: explanation.chain,
+      rootTag: explanation.rootTag,
+    },
+  };
 }
 
 declare const exports: Record<string, unknown>;
 exports.hasRoutingConfig = hasRoutingConfig;
+exports.hasActiveSubWikiRouting = hasActiveSubWikiRouting;
 exports.isWikiWorkspaceWithRouting = isWikiWorkspaceWithRouting;
 exports.workspaceSorter = workspaceSorter;
 exports.matchesDirectTag = matchesDirectTag;
+exports.getDirectTagMatch = getDirectTagMatch;
+exports.findTagTreePath = findTagTreePath;
 exports.matchesTagTree = matchesTagTree;
 exports.matchesCustomFilter = matchesCustomFilter;
+exports.getMatchedCustomFilter = getMatchedCustomFilter;
+exports.explainTiddlerRouting = explainTiddlerRouting;
 exports.matchTiddlerToWorkspace = matchTiddlerToWorkspace;
+exports.buildTiddlerRoutingInfo = buildTiddlerRoutingInfo;

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.type.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.type.ts
@@ -3,12 +3,35 @@
  */
 
 import type { IWikiWorkspace, IWorkspace } from '@services/workspaces/interface';
+import type { ITiddlerRoutingInfo } from './tiddlerRoutingInfo';
+
+interface ITiddlerRoutingExplanation {
+  workspace: IWikiWorkspace;
+  kind: 'direct-tag' | 'tag-tree' | 'filter';
+  chain: string;
+  rootTag?: string;
+}
 
 /**
  * Extended utilities interface with routing utilities
  */
 export interface ExtendedUtilities {
+  hasRoutingConfig(workspace: IWorkspace): boolean;
+  hasActiveSubWikiRouting(workspacesWithRouting: IWikiWorkspace[], mainWorkspaceId: string): boolean;
   isWikiWorkspaceWithRouting(workspace: IWorkspace, mainWorkspaceId: string): workspace is IWikiWorkspace;
+  findTagTreePath(
+    rootTag: string,
+    targetTitle: string,
+    wiki: typeof $tw.wiki,
+    maxDepth?: number,
+  ): string[] | undefined;
+  explainTiddlerRouting(
+    tiddlerTitle: string,
+    tiddlerTags: string[],
+    workspacesWithRouting: IWikiWorkspace[],
+    wiki: typeof $tw.wiki,
+    rootWidget: typeof $tw.rootWidget,
+  ): ITiddlerRoutingExplanation | undefined;
   matchTiddlerToWorkspace(
     tiddlerTitle: string,
     tiddlerTags: string[],
@@ -16,4 +39,12 @@ export interface ExtendedUtilities {
     wiki: typeof $tw.wiki,
     rootWidget: typeof $tw.rootWidget,
   ): IWikiWorkspace | undefined;
+  buildTiddlerRoutingInfo(
+    tiddlerTitle: string,
+    tiddlerTags: string[],
+    workspacesWithRouting: IWikiWorkspace[],
+    mainWorkspaceId: string,
+    wiki: typeof $tw.wiki,
+    rootWidget: typeof $tw.rootWidget,
+  ): ITiddlerRoutingInfo;
 }

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.type.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/routingUtilities.type.ts
@@ -3,11 +3,11 @@
  */
 
 import type { IWikiWorkspace, IWorkspace } from '@services/workspaces/interface';
-import type { ITiddlerRoutingInfo } from './tiddlerRoutingInfo';
+import type { ITiddlerRoutingInfo, TiddlerRoutingMatchKind } from './tiddlerRoutingInfo';
 
-interface ITiddlerRoutingExplanation {
+export interface ITiddlerRoutingExplanation {
   workspace: IWikiWorkspace;
-  kind: 'direct-tag' | 'tag-tree' | 'filter';
+  kind: TiddlerRoutingMatchKind;
   chain: string;
   rootTag?: string;
 }

--- a/src/services/wiki/plugin/watchFileSystemAdaptor/tiddlerRoutingInfo.ts
+++ b/src/services/wiki/plugin/watchFileSystemAdaptor/tiddlerRoutingInfo.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared DTO for tiddler → workspace routing explanation.
+ * Used by FileSystemAdaptor utils and exposed through wiki service IPC.
+ */
+
+export type TiddlerRoutingMatchKind = 'direct-tag' | 'tag-tree' | 'filter';
+
+export interface ITiddlerRoutingMatch {
+  workspaceId: string;
+  workspaceName: string;
+  isSubWiki: boolean;
+  kind: TiddlerRoutingMatchKind;
+  /** Human-readable chain, e.g. "RootTag → MidTag → ChildTitle", or a matched filter expression */
+  chain: string;
+  /** Root tag that won, when kind is tag-based */
+  rootTag?: string;
+}
+
+export interface ITiddlerRoutingInfo {
+  /**
+   * True when the current main wiki has at least one sub-wiki with routing settings enabled
+   * (tagNames and/or fileSystemPathFilter).
+   */
+  featureAvailable: boolean;
+  match?: ITiddlerRoutingMatch;
+}

--- a/src/services/wiki/wikiWorker/index.ts
+++ b/src/services/wiki/wikiWorker/index.ts
@@ -15,6 +15,7 @@ import { Observable } from 'rxjs';
 
 import type { IWikiWorkspace } from '@services/workspaces/interface';
 import { IZxWorkerMessage, ZxWorkerControlActions } from '../interface';
+import type { ITiddlerRoutingInfo } from '../plugin/watchFileSystemAdaptor/tiddlerRoutingInfo';
 import { executeScriptInTWContext, executeScriptInZxScriptContext, extractTWContextScripts, type IVariableContextList } from '../plugin/zxPlugin';
 import { wikiOperationsInWikiWorker } from '../wikiOperations/executor/wikiOperationInServer';
 import { getWikiInstance } from './globals';
@@ -116,10 +117,20 @@ async function beforeExit(): Promise<void> {
   }
 }
 
+async function getTiddlerRoutingInfo(tiddlerTitle: string): Promise<ITiddlerRoutingInfo> {
+  const wikiInstance = getWikiInstance();
+  const syncAdaptor = wikiInstance?.syncadaptor as { getTiddlerRoutingInfo?: (title: string) => Promise<ITiddlerRoutingInfo> } | undefined;
+  if (syncAdaptor?.getTiddlerRoutingInfo) {
+    return await syncAdaptor.getTiddlerRoutingInfo(tiddlerTitle);
+  }
+  return { featureAvailable: false };
+}
+
 // All exposed methods should be async.
 const wikiWorker = {
   startNodeJSWiki,
   getTiddlerFileMetadata: async (tiddlerTitle: string) => getWikiInstance()?.boot.files[tiddlerTitle],
+  getTiddlerRoutingInfo,
   executeZxScript,
   extractWikiHTML,
   packetHTMLFromWikiFolder,


### PR DESCRIPTION
## Summary
- Add `getTiddlerRoutingInfo` so plugins can read the same FileSystemAdaptor workspace routing decision and winning tag/filter chain.
- Keep existing workspace-order priority; expose `featureAvailable` when the main wiki has at least one routed sub-wiki.
- Cover routing helpers and adaptor behavior with unit tests under `watchFileSystemAdaptor/__tests__`.

## Test plan
- [ ] CI unit tests pass (especially `watchFileSystemAdaptor` routing suites)
- [ ] With a main wiki + private sub-wiki (tag tree / tags / filter), call `window.service.wiki.getTiddlerRoutingInfo(title)` and confirm `match.chain` / `workspaceName` / `isSubWiki`
- [ ] Confirm `featureAvailable` is false when no routed sub-wiki exists
- [ ] Saving a tiddler still routes to the same workspace as before this API (order-first match unchanged)