### PR TITLE
chore(ci): isolate Release App concurrency group per branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,10 @@ on:
       - ".vscode"
 
 concurrency:
-  group: release-ci-group
+  # Per-branch group so PRs/branches run in parallel without cancelling each other.
+  # Same-branch pushes still cancel stale same-branch runs. GitHub Actions usage is
+  # well below the limit, so we prefer isolation over aggressive cross-branch cancellation.
+  group: release-ci-group-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- The `Release App` workflow used a repo-wide concurrency group `release-ci-group` with `cancel-in-progress: true`. When multiple agents/PRs develop in parallel, any new run cancels in-progress runs from other branches, repeatedly cancelling e2e before it can finish.
- Switch the group to `release-ci-group-${{ github.ref }}` so each branch/PR gets its own group: different branches run in parallel without interfering, while same-branch pushes still cancel stale same-branch runs.
- GitHub Actions usage is far below the limit, so aggressive cross-branch cancellation is unnecessary.

## Test plan
- [x] `pnpm run check` + `pnpm run lint --max-warnings 0` pass (pre-push hook)
- [ ] Confirm two PRs from different branches no longer cancel each other's `Release App` runs
