### PR TITLE
fix(linux): use TidGi icons in native packages

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -28,7 +28,9 @@ const config: ForgeConfig = {
         schemes: ['tidgi'],
       },
     ],
-    icon: 'build-resources/icon.ico',
+    // Let Electron Packager select the platform-specific file extension
+    // (.ico on Windows, .icns on macOS, and .png on Linux).
+    icon: 'build-resources/icon',
     asar: {
       // Unpack worker files, utility process files, native modules path, and ALL .node binaries (including better-sqlite3)
       // UtilityProcess files must be unpacked because utilityProcess.fork() reads from the
@@ -40,6 +42,8 @@ const config: ForgeConfig = {
       'template/wiki',
       'build-resources/tidgiMiniWindow@2x.png',
       'build-resources/tidgiMiniWindowTemplate@2x.png',
+      // Linux BrowserWindow icons are loaded at runtime rather than embedded in the executable.
+      'build-resources/icon.png',
       // Packaged for squirrelStartup to copy to %LocalAppData%\tidgi\app.ico (uninstall DisplayIcon).
       'build-resources/icon.ico',
     ],
@@ -103,6 +107,8 @@ const config: ForgeConfig = {
         options: {
           maintainer: 'Lin Onetwo <linonetwo012@gmail.com>',
           mimeType: ['x-scheme-handler/tidgi'],
+          // electron-installer-debian otherwise installs its bundled Electron icon.
+          icon: 'build-resources/icon.png',
         },
       },
     },
@@ -113,6 +119,7 @@ const config: ForgeConfig = {
         options: {
           maintainer: 'Lin Onetwo <linonetwo012@gmail.com>',
           mimeType: ['x-scheme-handler/tidgi'],
+          icon: 'build-resources/icon.png',
         },
       },
     },

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -34,6 +34,12 @@ export const sourcePath = isPackaged
 export const buildResourcePath = path.resolve(sourcePath, 'build-resources');
 export const developmentImageFolderPath = path.resolve(sourcePath, 'images');
 
+// Linux window icons are not embedded in the executable. Keep the packaged path
+// in sync with packagerConfig.extraResource in forge.config.ts.
+export const TIDGI_APP_ICON_PATH = isPackaged
+  ? path.resolve(process.resourcesPath, 'icon.png')
+  : path.resolve(buildResourcePath, 'icon.png');
+
 // TidGi Mini Window icon
 const tidgiMiniWindowIconFileName = isMac ? 'tidgiMiniWindowTemplate@2x.png' : 'tidgiMiniWindow@2x.png';
 export const TIDGI_MINI_WINDOW_ICON_PATH = isPackaged

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -1,5 +1,7 @@
 import { isTest } from '@/constants/environment';
 import { getOAuthConfig } from '@/constants/oauthConfig';
+import { TIDGI_APP_ICON_PATH } from '@/constants/paths';
+import { isLinux } from '@/helpers/system';
 import { container } from '@services/container';
 import type { IDatabaseService } from '@services/database/interface';
 import type { IGitUserInfos } from '@services/git/interface';
@@ -191,6 +193,7 @@ export class Authentication implements IAuthenticationService {
           contextIsolation: true,
         },
         title: 'OAuth Login',
+        ...(isLinux ? { icon: TIDGI_APP_ICON_PATH } : {}),
         resizable: true,
         minimizable: false,
         fullscreenable: false,

--- a/src/services/view/handleNewWindow.ts
+++ b/src/services/view/handleNewWindow.ts
@@ -4,7 +4,9 @@ import windowStateKeeper from 'electron-window-state';
 import { SETTINGS_FOLDER } from '@/constants/appPaths';
 import { MetaDataChannel } from '@/constants/channels';
 import { isTest } from '@/constants/environment';
+import { TIDGI_APP_ICON_PATH } from '@/constants/paths';
 import { TIDGI_PROTOCOL_SCHEME } from '@/constants/protocol';
+import { isLinux } from '@/helpers/system';
 import { extractDomain, isInternalUrl } from '@/helpers/url';
 import { container } from '@services/container';
 import type { IDeepLinkService } from '@services/deepLink/interface';
@@ -129,6 +131,7 @@ export function handleNewWindow(
       height: windowWithBrowserViewState.height,
       webPreferences,
       autoHideMenuBar: true,
+      ...(isLinux ? { icon: TIDGI_APP_ICON_PATH } : {}),
       // Keep the window hidden during E2E tests so it won't steal focus from the developer.
       // Set SHOW_E2E_WINDOW=1 to override and show windows during manual E2E observation.
       ...(isTest && !process.env.SHOW_E2E_WINDOW ? { show: false } : {}),

--- a/src/services/windows/index.ts
+++ b/src/services/windows/index.ts
@@ -16,6 +16,7 @@ import type { IWorkspaceViewService } from '@services/workspacesView/interface';
 import { SETTINGS_FOLDER } from '@/constants/appPaths';
 import { isTest } from '@/constants/environment';
 import { DELAY_MENU_REGISTER } from '@/constants/parameters';
+import { TIDGI_APP_ICON_PATH } from '@/constants/paths';
 import { getDefaultTidGiUrl } from '@/constants/urls';
 import { isLinux, isMac } from '@/helpers/system';
 import { container } from '@services/container';
@@ -248,6 +249,7 @@ export class Window implements IWindowService {
       minimizable: true,
       fullscreenable: true,
       autoHideMenuBar,
+      ...(isLinux ? { icon: TIDGI_APP_ICON_PATH } : {}),
       titleBarStyle: hideTitleBar ? 'hidden' : 'default',
       // Keep the window hidden during E2E tests so it won't steal focus from the developer.
       // Set SHOW_E2E_WINDOW=1 to override and show windows during manual E2E observation.


### PR DESCRIPTION
## Summary

- configure Electron Packager to select the platform-specific app icon
- explicitly provide the TidGi PNG to the DEB and RPM makers instead of their bundled Electron default
- package the PNG as a runtime resource and apply it to Linux application windows

## Root cause

`electron-installer-debian` uses its own bundled icon when `options.icon` is omitted. In addition, Linux window icons are not embedded in the executable, so BrowserWindow instances need a runtime icon path.

## Verification

- `tsc --noEmit --skipLibCheck`
- ESLint on all changed TypeScript files with `--max-warnings 0`
- built `tidgi_0.14.2-prerelease2_amd64.deb` with Electron Forge
- extracted the DEB and verified both `/usr/share/pixmaps/tidgi.png` and `/usr/lib/tidgi/resources/icon.png` have the same SHA-256 as `build-resources/icon.png`
- verified the generated desktop entry uses `Icon=tidgi`

## Related issue

Issue #732 was an external AUR PKGBUILD checksum mismatch. The current AUR package has already corrected the checksum; fresh-clone verification details were added to the issue before closing it.